### PR TITLE
docs: clarify Connect Bedrock support paths

### DIFF
--- a/.web/docs/.vitepress/config.ts
+++ b/.web/docs/.vitepress/config.ts
@@ -121,6 +121,10 @@ export default defineConfig({
                             link: '/guide/joining'
                         },
                         {
+                            text: 'Bedrock Support',
+                            link: '/guide/bedrock'
+                        },
+                        {
                             text: 'Public Localhost',
                             link: '/guide/localhost'
                         },

--- a/.web/docs/guide/bedrock.md
+++ b/.web/docs/guide/bedrock.md
@@ -1,0 +1,65 @@
+# Bedrock Support
+
+Connect lets Bedrock players join connected endpoints through the same public addresses Java players already use:
+
+- `<endpoint>.play.minekube.net`
+- custom domains attached to the endpoint
+- endpoint routing through the Connect network
+
+For Connect-routed players, Bedrock translation is handled by the Connect edge before traffic reaches your connector.
+That means the usual Connect setup stays the same for Paper/Spigot, Velocity, BungeeCord, and Gate connectors.
+
+## Which Setup Do I Need?
+
+| Setup | What to configure | Who handles Bedrock translation |
+| --- | --- | --- |
+| Connect Plugin on Paper/Spigot, Velocity, or BungeeCord | Install and run the Connect plugin normally | Connect edge |
+| Standard Gate with `connect` enabled | Enable Connect normally | Connect edge for Connect-routed players |
+| Standard Gate with direct Bedrock clients | Add `bedrock: true` to Gate | Your Gate instance |
+| Standard Gate with both Connect and direct Bedrock | Enable Connect and `bedrock: true` | Connect edge for Connect addresses, Gate for direct Bedrock address |
+| Gate Lite behind Connect | Configure Gate Lite as a Java connector | Connect edge for Connect-routed Bedrock players |
+| Gate Lite as a direct Bedrock listener | Use standard Gate instead | Not supported in Gate Lite |
+
+## Connect-Routed Bedrock
+
+Use this path when players join through Connect addresses such as `<endpoint>.play.minekube.net`, `minekube.net`, or a
+custom domain attached to your endpoint.
+
+You do not need to:
+
+- install Geyser on your backend
+- install Floodgate on your backend
+- open a local UDP Bedrock port
+- set `bedrock: true` in your backend Gate just for Connect players
+
+This applies to the Connect Java plugin and to Gate used as a Connect connector.
+
+## Direct Self-Hosted Gate Bedrock
+
+Use this path when Bedrock players connect directly to a Gate address you operate yourself, outside the Connect network.
+In that case, standard Gate can manage Bedrock locally:
+
+```yaml
+bedrock: true
+```
+
+With that setting, Gate starts and manages the Bedrock translation runtime for direct Bedrock clients. This local setting
+does not change how Connect-routed Bedrock players are handled.
+
+## Domains
+
+Connect domains are shared by Java and Bedrock players. If a custom domain already routes Java players to your endpoint,
+Bedrock players use the same domain after it is attached to the endpoint in the dashboard.
+
+Use a separate direct Bedrock address only when you intentionally run local Bedrock support on your own standard Gate
+instance.
+
+## Account Linking and Online Mode
+
+Connect-routed Bedrock players arrive through the managed Bedrock path and are represented through the compatibility
+layer before they reach your connector. Servers that require a linked Java account may still reject Bedrock players who
+have not linked their account. In that case, the player needs to link their Bedrock account with the Java account expected
+by the target server.
+
+If you are troubleshooting online-mode behavior, first identify whether the player joined through a Connect address or a
+direct self-hosted Gate Bedrock address. The required configuration is different for those two paths.

--- a/.web/docs/guide/connectors/gate.md
+++ b/.web/docs/guide/connectors/gate.md
@@ -22,11 +22,19 @@ For an introduction to Gate, see [Gate Docs](https://gate.minekube.com/guide).
 As one of the most capable open source Minecraft proxy in the world, Gate has first class support for Connect with
 online-mode.
 
+Connect-routed Bedrock players are translated by the Connect edge before they reach your Gate connector. You do not
+need `bedrock: true` in your Gate config for that path. Enable `bedrock: true` only when Bedrock players should connect
+directly to your self-hosted Gate instance instead of through a Connect address.
+
 -> To customize Gate checkout the [starter plugin template](https://github.com/minekube/gate-plugin-template)
 
 ## Gate Lite Mode
 
 For an introduction to Gate Lite mode, see [Gate Lite Docs](https://gate.minekube.com/guide/lite).
+
+Gate Lite remains a thin Java protocol reverse proxy. It can sit behind Connect as a connector for Java traffic, while
+Connect-routed Bedrock translation happens at the Connect edge. Use standard Gate, not Gate Lite, if you want your own
+direct Bedrock listener.
 
 ::: tip Coming Soon -> Allowing online mode in Gate Lite backend routes
 

--- a/.web/docs/guide/connectors/index.md
+++ b/.web/docs/guide/connectors/index.md
@@ -14,6 +14,9 @@ creating secure outbound tunnels for receiving player connections.
 
 - Enable `connect` mode in the configuration to use it as a Connector for your
   server. Gate is updated most frequently and has the most capabilities.
+- Connect-routed Bedrock players are translated by the Connect edge before they reach
+  your connector. Enable local Gate Bedrock only when Bedrock players should connect
+  directly to your self-hosted Gate address.
 - If you have an existing Java proxy, switch to [Gate Lite mode](gate.md#gate-lite-mode) to use it as a Connector
   without installing the Connect Java Plugin.
 
@@ -23,6 +26,8 @@ creating secure outbound tunnels for receiving player connections.
 
 - The Spigot/Velocity/Bungee Connect Plugin can be installed on your Minecraft server/proxy to
   use it as a Connector for your endpoints.
+- Bedrock players can join these connected endpoints through the same Connect addresses.
+  No Geyser plugin or extra Bedrock proxy is required for the Connect-routed path.
 
 -> Continue wit [Java Plugin Setup Guide](plugin.md)
 
@@ -65,7 +70,7 @@ globally, effectively reducing latency and securing the data path.
 ::: info When the Player and Connector are in the same region
 Note that if both the Player and Connector are in the same region, they will likely be routed to the same Edge, thus
 the Connector will create the Tunnel directly to the Edge the Player is connected. Only one Edge would be involved in the diagram.
-::: 
+:::
 
 -> Why all that? Checkout [Connect Tunnels](/guide/tunnels) explained!
 
@@ -81,4 +86,4 @@ Connectors when
 distributing the player connections. If you want this behavior, let us know in
 our [Discord](https://minekube.com/discord)!
 
-::: 
+:::

--- a/.web/docs/guide/domains.md
+++ b/.web/docs/guide/domains.md
@@ -21,6 +21,10 @@ You’ll need to configure this with your DNS provider. The example screenshot u
 
 Now, accessing `example.com` will tell the DNS system to look up `mcserver.play.minekube.net` and return its results.
 
+Java and Bedrock players can use the same verified custom domain. Connect-routed
+Bedrock translation happens at the Connect edge, so the domain still points at the
+same endpoint and does not need a separate Bedrock-only record.
+
 ## Or, set an SRV record <VPBadge>Option 2</VPBadge>
 
 If you want to use an SRV record instead of a CNAME, you can do that too. Use an SRV record if

--- a/.web/docs/guide/index.md
+++ b/.web/docs/guide/index.md
@@ -89,6 +89,7 @@ the plugin will ask the [Random Name Service](https://randomname.minekube.net/).
 - [Joining guide](/guide/joining) - Learn how to join endpoints.
 - [Advertising guide](/guide/advertising) - Learn about advertising your endpoints.
 - [Endpoint Domains guide](/guide/domains) - Learn how to use free domains for your endpoints.
+- [Bedrock support guide](/guide/bedrock) - Learn which Bedrock path applies to your setup.
 - [Offline Mode guide](/guide/offline-mode) - Learn how to allow offline mode players on your server.
 
 ## Connect Tunnels

--- a/.web/docs/guide/quick-start.md
+++ b/.web/docs/guide/quick-start.md
@@ -37,6 +37,10 @@ that you can reset in the Dashboard at any time.
 Your Minecraft server is now protected by the Connect Network and players can join it
 at `<endpoint>.play.minekube.net`!
 
+Java and Bedrock players use the same endpoint address. Bedrock support is handled by
+the Connect edge for Connect-routed players, so Paper/Spigot, Velocity, and BungeeCord
+plugin users do not need to install Geyser or change Gate Bedrock settings.
+
 **Next Steps:** Consider to import your Endpoints to the Connect Dashboard.
 
 ## Getting Help

--- a/.web/docs/index.md
+++ b/.web/docs/index.md
@@ -54,6 +54,10 @@ features:
     details: Securely connect to the open Connect Network to link and advertise your game servers.
     link: /guide/#the-connect-network
     linkText: The Connect Network
+  - title: Java and Bedrock Access
+    details: Let Bedrock players join connected endpoints through the same domains Java players use.
+    link: /guide/bedrock
+    linkText: Bedrock Support
   - icon: 📦
     title: Quick Installation
     details: All you need is the Connect Plugin to link your game servers with the open Connect Network.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ Connect now lets Bedrock players join connected servers through the same endpoin
 the Connect plugin on Paper/Spigot, Velocity, or BungeeCord, there is no Geyser plugin
 or extra Bedrock proxy to install.
 
-Self-hosted Gate users can enable the same managed Bedrock path with one config line:
+If you self-host standard Gate and want Bedrock players to connect directly to that Gate
+instance, enable Gate-managed Bedrock with one config line:
 
 ```yaml
 bedrock: true
 ```
+
+You do not need this setting just to receive Bedrock players through the Connect network.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- add a dedicated Bedrock support matrix for Connect-routed vs direct self-hosted Gate paths
- clarify that Connect plugin and Connect-routed Gate users do not need local `bedrock: true`
- surface Bedrock support from quick start, domains, connector docs, guide index, homepage, and README

## Verification
- `git diff --check`
- `yarn build` from `.web`
- checked static build output contains `guide/bedrock.html` and the new matrix content

Note: Chrome DevTools browser verification was blocked by an already-running locked profile in this session, so I used VitePress build output verification instead.