### PR TITLE
Document Connect forwarding topologies

### DIFF
--- a/.web/docs/.vitepress/config.ts
+++ b/.web/docs/.vitepress/config.ts
@@ -133,6 +133,14 @@ export default defineConfig({
                             link: '/guide/domains'
                         },
                         {
+                            text: 'Forwarding and Topologies',
+                            link: '/guide/topologies'
+                        },
+                        {
+                            text: 'Compatibility Matrix',
+                            link: '/guide/compatibility'
+                        },
+                        {
                             text: 'Offline Mode',
                             link: '/guide/offline-mode'
                         },

--- a/.web/docs/guide/compatibility.md
+++ b/.web/docs/guide/compatibility.md
@@ -1,0 +1,64 @@
+# Compatibility Matrix
+
+Connect works best when the Minecraft ingress path is simple and each layer has one responsibility. This matrix captures
+the combinations that most often need extra care.
+
+## Platforms
+
+| Platform | Connect support | Notes |
+| --- | --- | --- |
+| Paper and Spigot | Supported with the Connect plugin | Recommended for single-server setups. Keep direct backend access closed unless intentionally public. |
+| Velocity | Supported with the Connect plugin | Use stable Velocity builds when possible. Snapshot builds may change internals that proxy plugins rely on. |
+| BungeeCord | Supported with the Connect plugin | Make sure backend forwarding and online-mode behavior match your BungeeCord setup. |
+| Standard Gate | Supported as a Connect connector | Connect-routed Bedrock is handled at the Connect edge. Direct Gate Bedrock needs standard Gate with `bedrock: true`. |
+| Gate Lite | Can be used as a Java connector behind Connect | Gate Lite is not the direct Bedrock listener. Use standard Gate for direct self-hosted Bedrock. |
+| Sponge or Minestom | Not a primary Connect plugin target | Put a supported proxy or server in front, or test carefully before using in production. |
+
+## Proxy and Login Plugins
+
+| Component | Risk | Recommended support response |
+| --- | --- | --- |
+| Velocity snapshots | Medium | Ask for the exact Velocity build and Connect plugin version. Reproduce on a stable Velocity build if packet or login behavior changed. |
+| FastLogin, AuthMe, NLogin, and similar login plugins | Medium to high | Ask whether the server is online-mode, offline-mode, or mixed. Confirm whether the player joined through Connect, TCPShield, direct proxy, or direct backend. |
+| MultiProxySync and profile/skin sync plugins | Medium | Check whether UUID/profile data is expected from the proxy, backend, or plugin. Compare behavior between the direct proxy path and the Connect path. |
+| TCPShield in front of Java while Connect handles Bedrock | Medium | Treat as two ingress paths. Ask which hostname the player used and whether forwarding is configured consistently on both paths. |
+| Backend direct public access | High | Players can bypass forwarding and authentication assumptions. Recommend closing direct backend access or documenting it as a separate path. |
+
+## Modded and Hybrid Servers
+
+| Server type | Risk | Notes |
+| --- | --- | --- |
+| Vanilla-compatible Paper or Spigot | Low | Best supported path. |
+| Forge or NeoForge behind a supported proxy | Medium | Test login and plugin-message behavior. Some modded handshakes assume a direct client-to-server path. |
+| Arclight, Ketting, Mohist, Magma, and other hybrid servers | High | Hybrid server internals vary. Ask for exact server type/version and logs before recommending a Connect or proxy setting. |
+| Fabric servers with proxy support | Medium | Verify the proxy forwarding plugin/mod expected by the backend. |
+| Modpacks requiring custom client handshakes | Medium to high | Confirm whether the proxy and backend both support the required handshake. |
+
+## Bedrock and Account Linking
+
+Connect-routed Bedrock players use the same Connect endpoint names and custom domains as Java players. The Connect edge
+handles Bedrock translation before traffic reaches your connector.
+
+If a Bedrock player can ping but cannot join:
+
+- confirm the player joined a Connect address, not a direct Gate address
+- check whether the target server requires a linked Java account
+- check whether the kick is from the Connect edge, the connector, the proxy, or the backend
+- avoid recommending backend Geyser, Floodgate, UDP port opening, or `bedrock: true` unless the user wants direct
+  Bedrock clients to hit their own standard Gate instance
+
+## What to Ask For
+
+For compatibility reports, ask for the smallest useful set of facts:
+
+- player address used to join
+- Java or Bedrock client
+- connector type and version
+- backend/proxy type and version
+- whether there is TCPShield, Velocity, BungeeCord, Gate, or direct backend access in the path
+- exact kick text and logs around the timestamp
+- whether the issue reproduces through another address
+
+That information usually tells support whether the issue belongs to Connect ingress, proxy forwarding, backend auth,
+modded handshake compatibility, or local server configuration.
+

--- a/.web/docs/guide/topologies.md
+++ b/.web/docs/guide/topologies.md
@@ -1,0 +1,86 @@
+# Forwarding and Topologies
+
+Connect can sit in front of many Minecraft server layouts. The important first step is to identify which address the
+player uses and which component is responsible for authentication, forwarding, and Bedrock translation.
+
+## Choose the Right Path
+
+| Player address | Connector | Backend sees | Bedrock support | Use this when |
+| --- | --- | --- | --- | --- |
+| `<endpoint>.play.minekube.net`, `minekube.net`, or a Connect custom domain | Connect plugin on Paper, Spigot, Velocity, or BungeeCord | The server or proxy running the plugin | Managed by the Connect edge | You want the simplest managed Connect setup |
+| `<endpoint>.play.minekube.net`, `minekube.net`, or a Connect custom domain | Standard Gate with `connect` enabled | Your Gate instance, then its configured Java backends | Managed by the Connect edge for Connect-routed players | You already operate Gate and want Connect ingress |
+| A hostname or IP that points directly at your Gate instance | Standard Gate | Your Gate instance, then its configured Java backends | Gate handles it only when `bedrock: true` is enabled | You self-host Gate and want direct Bedrock clients outside Connect |
+| A TCPShield Java address plus a Connect Bedrock address | TCPShield for Java, Connect for Bedrock | Your backend may see two separate ingress paths | Connect handles Bedrock only on the Connect address | You intentionally keep Java and Bedrock ingress separate |
+| A public backend IP or port | None | Backend directly | Not managed by Connect | Development only, or a deliberate direct public setup |
+
+If the player joined through a Connect address, do not diagnose it as direct Gate Bedrock or direct backend traffic.
+
+## Paper or Spigot With the Connect Plugin
+
+This is the smallest setup. Install the Connect plugin and let players join the endpoint name, `play.minekube.net`
+subdomain, or custom domain attached in the dashboard.
+
+Use this topology when:
+
+- the backend is a single Paper or Spigot server
+- you want Connect to manage public ingress
+- Bedrock players should join through the same Connect address as Java players
+
+Keep Paper `online-mode=true` unless you intentionally run an offline-mode server. If you allow offline-mode players,
+use the Connect plugin's `allow-offline-mode-players` setting instead of opening a second direct backend path.
+
+## Velocity or BungeeCord With the Connect Plugin
+
+Install the Connect plugin on the proxy when the proxy is the public entry point for the network. The proxy then keeps
+its normal forwarding relationship with backend servers.
+
+Check these pieces first when players join but have the wrong UUID, skin, permissions, or login state:
+
+- the Connect plugin is installed on the proxy, not only on one backend server
+- backend servers are configured for the proxy forwarding mode you already use
+- Velocity, BungeeCord, Paper, and login plugins agree on online-mode behavior
+- players are not bypassing the proxy through a direct backend address
+
+Connect does not replace Velocity or BungeeCord forwarding between your proxy and backend servers. It gives the proxy a
+managed public ingress path.
+
+## Standard Gate With Connect Enabled
+
+Use this topology when Gate is your Java proxy and you want Connect to expose it through the Connect network. Connect
+players reach the Connect edge first, then your Gate connector, then Gate routes to its configured backend servers.
+
+For Connect-routed Bedrock players, translation is already handled before traffic reaches your Gate connector. You do
+not need `bedrock: true` just because players use a Connect address.
+
+Enable `bedrock: true` only when Bedrock clients also connect directly to the Gate address you host yourself.
+
+## TCPShield and Connect Together
+
+Some networks keep TCPShield for Java traffic while adding Connect for managed Bedrock or additional endpoint routing.
+That can work, but treat it as two ingress paths:
+
+- Java players using the TCPShield address follow the TCPShield and proxy forwarding path.
+- Java or Bedrock players using a Connect address follow the Connect path.
+- Account, UUID, skin, and IP-forwarding behavior can differ between those paths if the backend/proxy is not configured
+  consistently.
+
+When debugging, always ask which address the player used. A kick that happens through `minekube.net` may not reproduce
+through a TCPShield hostname, and the reverse is also true.
+
+## Direct Backend Connections
+
+Direct backend connections are useful for local debugging but should not be mixed casually with Connect or proxy
+ingress. If players can bypass the proxy and join a backend directly, the backend may see different online-mode,
+forwarding, UUID, skin, permission, or IP information.
+
+For production, prefer one public path per player group and make the backend reject unintended direct traffic.
+
+## Quick Debug Checklist
+
+1. Ask for the exact address the player joined.
+2. Identify the connector: Paper/Spigot plugin, Velocity plugin, BungeeCord plugin, or Gate connector.
+3. Identify whether the player is Java or Bedrock.
+4. Identify whether Bedrock is Connect-routed or direct Gate Bedrock.
+5. Check whether the backend is reachable directly and whether players might bypass the intended proxy.
+6. For UUID, skin, permission, or login issues, check forwarding and login-plugin configuration before changing Connect.
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ bedrock: true
 
 You do not need this setting just to receive Bedrock players through the Connect network.
 
+For proxy, TCPShield, direct-backend, and login-plugin setups, see the
+[forwarding and topology guide](https://connect.minekube.com/guide/topologies) and
+[compatibility matrix](https://connect.minekube.com/guide/compatibility).
+
 ## Features
 
 - [x] ProtoBuf typed


### PR DESCRIPTION
## Summary
- add a forwarding/topology guide for Connect plugin, Gate, TCPShield, direct backend, and Bedrock paths
- add a compatibility matrix for Velocity snapshots, login plugins, proxy/profile sync, and modded/hybrid servers
- link the guides from the sidebar and README Bedrock section

## Verification
- `git diff --check`
- `yarn install`
- `yarn build`

Build completed successfully. Existing warnings: Yarn peer/build-script warnings during install; VitePress `rhyme` highlighter fallback, Node `module.register()` deprecation, and large chunk warning during build.