### PR TITLE
Fix plans page theme styling

### DIFF
--- a/.web/docs/.vitepress/theme/components/plans/two_tiers_with_emphasized_tier.vue
+++ b/.web/docs/.vitepress/theme/components/plans/two_tiers_with_emphasized_tier.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="relative isolate px-6 py-24 sm:py-32 lg:px-8">
+  <div class="relative isolate px-6 pt-24 pb-16 sm:pt-32 sm:pb-20 lg:px-8">
     <div class="absolute inset-x-0 -top-3 -z-10 transform-gpu overflow-hidden px-36 blur-3xl" aria-hidden="true">
       <div class="mx-auto aspect-[1155/678] w-[72.1875rem] bg-gradient-to-tr from-[--vp-c-brand-1] to-[#ff80b5] opacity-30" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)" />
     </div>
     <div class="mx-auto max-w-2xl text-center lg:max-w-4xl">
       <h2 class="text-base font-semibold leading-7 text-[--vp-c-brand-2]">Minekube Connect</h2>
       <p class="mt-2 text-4xl font-bold tracking-tight text-[--vp-c-text-1] sm:text-5xl">Pricing Plans</p>
+      <div class="mx-auto mt-6 max-w-xl text-center text-lg leading-8 text-[--vp-c-text-2]">Use Minekube for free with your whole team. Upgrade to opt out of the Browser ecosystem and enable additional features.</div>
     </div>
-    <p class="mx-auto mt-6 max-w-2xl text-center text-lg leading-8 text-[--vp-c-text-1]">Use Minekube for free with your whole team. Upgrade to opt out of Browser ecosystem, and enable additional features.</p>
     <div class="mx-auto mt-16 grid max-w-lg grid-cols-1 items-center gap-y-6 sm:mt-20 sm:gap-y-0 lg:max-w-4xl lg:grid-cols-2">
-      <div v-for="(tier, tierIdx) in tiers" :key="tier.id" :class="[tier.featured ? 'dark relative bg-red-950 shadow-2xl' : 'dark:bg-transparent/60 bg-[--vp-c-default-soft] sm:mx-8 lg:mx-0', tier.featured ? '' : tierIdx === 0 ? 'rounded-t-3xl sm:rounded-b-none lg:rounded-tr-none lg:rounded-bl-3xl' : 'sm:rounded-t-none lg:rounded-tr-3xl lg:rounded-bl-none', 'rounded-3xl p-8 ring-1 ring-gray-900/10 sm:p-10']">
+      <div v-for="(tier, tierIdx) in tiers" :key="tier.id" :class="[tier.featured ? 'relative bg-[var(--vp-c-bg-soft)] shadow-2xl ring-2 ring-[var(--vp-c-brand-2)]' : 'bg-[var(--vp-c-default-soft)] sm:mx-8 lg:mx-0', tier.featured ? '' : tierIdx === 0 ? 'rounded-t-3xl sm:rounded-b-none lg:rounded-tr-none lg:rounded-bl-3xl' : 'sm:rounded-t-none lg:rounded-tr-3xl lg:rounded-bl-none', 'rounded-3xl p-8 ring-1 ring-[var(--vp-c-divider)] sm:p-10']">
         <h3 :id="tier.id" :class="[tier.featured ? 'text-[--vp-c-brand-2]' : 'text-[--vp-c-brand-2]', 'text-base font-semibold leading-7']">{{ tier.name }}</h3>
         <p class="mt-4 flex items-baseline gap-x-2">
           <span v-if="!(discount.active && tier.featured)" :class="[tier.featured ? 'text-[--vp-c-text-1]' : 'text-[--vp-c-text-1]', 'text-5xl font-bold tracking-tight']">{{ tier.priceMonthly }}</span>
@@ -30,7 +30,7 @@
             {{ feature }}
           </li>
         </ul>
-        <a :href="tier.href" :aria-describedby="tier.id" :class="[tier.featured ? 'bg-white text-black shadow-sm hover:bg-red-600 hover:text-white focus-visible:outline-indigo-500' : 'bg-[--vp-button-brand-bg] text-[--vp-button-brand-text] hover:bg-[--vp-button-brand-hover-bg] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--vp-button-brand-active-bg]', 'mt-8 block rounded-md py-2.5 px-3.5 text-center text-sm font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 sm:mt-10']">{{ tier.ctaText || 'Get started today' }}</a>
+        <a :href="tier.href" :aria-describedby="tier.id" :class="[tier.featured ? 'bg-[var(--vp-button-brand-bg)] text-[var(--vp-button-brand-text)] hover:bg-[var(--vp-button-brand-hover-bg)] focus-visible:outline-[var(--vp-button-brand-active-bg)]' : 'bg-[var(--vp-button-brand-bg)] text-[var(--vp-button-brand-text)] hover:bg-[var(--vp-button-brand-hover-bg)] focus-visible:outline-[var(--vp-button-brand-active-bg)]', 'mt-8 block rounded-md py-2.5 px-3.5 text-center text-sm font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 sm:mt-10']">{{ tier.ctaText || 'Get started today' }}</a>
       </div>
     </div>
   </div>

--- a/.web/docs/.vitepress/theme/components/plans/with_comparison_table_on_dark.vue
+++ b/.web/docs/.vitepress/theme/components/plans/with_comparison_table_on_dark.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="py-24 sm:py-32">
+  <div class="pt-8 pb-24 sm:pt-12 sm:pb-32">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <div class="mx-auto max-w-4xl text-center">
         <h2 class="text-base font-semibold leading-7 text-[--vp-c-brand-2]">
@@ -11,13 +11,13 @@
           Plans for projects of&nbsp;all&nbsp;sizes
         </p>
       </div>
-      <p
+      <div
         class="mx-auto mt-6 max-w-2xl text-center text-lg leading-8 text-[--vp-c-text-1]"
       >
         Not ready for Plus? Every organization starts on the generous Free
         forever plan. It’s great for side projects, or learning how to use
         Minekube
-      </p>
+      </div>
 
       <!-- xs to lg -->
       <div class="mx-auto mt-12 max-w-md space-y-8 sm:mt-16 lg:hidden">
@@ -26,7 +26,7 @@
           :key="tier.id"
           :class="[
             tier.mostPopular
-              ? 'rounded-xl bg-white/5 ring-1 ring-inset ring-white/10'
+              ? 'rounded-xl bg-[var(--vp-c-bg-soft)] ring-1 ring-inset ring-[var(--vp-c-brand-2)]/40'
               : '',
             'p-8',
           ]"
@@ -58,8 +58,8 @@
             :aria-describedby="tier.id"
             :class="[
               tier.mostPopular
-                ? 'bg-indigo-500 text-[--vp-c-text-1] hover:bg-indigo-400 focus-visible:outline-indigo-500'
-                : 'bg-white/10 text-[--vp-c-text-1] hover:bg-white/20 focus-visible:outline-white',
+                ? 'bg-[var(--vp-button-brand-bg)] text-[var(--vp-button-brand-text)] hover:bg-[var(--vp-button-brand-hover-bg)] focus-visible:outline-[var(--vp-button-brand-active-bg)]'
+                : 'bg-[var(--vp-c-default-soft)] text-[var(--vp-c-text-1)] hover:bg-[var(--vp-c-default-3)] focus-visible:outline-[var(--vp-c-brand-2)]',
               'mt-8 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
             ]"
             >{{ tier.ctaText || 'Buy plan' }}</a
@@ -93,7 +93,7 @@
                       {{ ' ' }}
                       <span
                         v-if="typeof feature.tiers[tier.name] === 'string'"
-                        class="text-sm leading-6 text-gray-400"
+                        class="text-sm leading-6 text-[--vp-c-text-2]"
                         >({{ feature.tiers[tier.name] }})</span
                       >
                     </span>
@@ -122,7 +122,7 @@
               }"
             >
               <div
-                class="w-full rounded-t-xl border-x border-t border-[--vp-button-brand-border]/10 dark:border-white/10 dark:bg-white/5 bg-gray-500/5"
+                class="w-full rounded-t-xl border-x border-t border-[var(--vp-c-brand-2)]/20 bg-[var(--vp-c-bg-soft)]"
               />
             </div>
           </div>
@@ -183,9 +183,9 @@
                     :href="tier.href"
                     :class="[
                       tier.mostPopular
-                        ? 'bg-black text-white dark:bg-white dark:text-black dark:hover:bg-red-600 hover:bg-red-600 dark:hover:text-[--vp-c-text-1] focus-visible:outline-indigo-600'
-                        : 'bg-[--vp-button-brand-bg] text-[--vp-button-brand-text] hover:bg-[--vp-button-brand-hover-bg] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--vp-button-brand-active-bg]',
-                      'mt-8 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 text-[--vp-c-text-1] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+                        ? 'bg-[var(--vp-button-brand-bg)] text-[var(--vp-button-brand-text)] hover:bg-[var(--vp-button-brand-hover-bg)] focus-visible:outline-[var(--vp-button-brand-active-bg)]'
+                        : 'bg-[var(--vp-c-default-soft)] text-[var(--vp-c-text-1)] hover:bg-[var(--vp-c-default-3)] focus-visible:outline-[var(--vp-c-brand-2)]',
+                      'mt-8 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
                     ]"
                     >{{ tier.ctaText || 'Buy plan' }}</a
                   >


### PR DESCRIPTION
## Summary
- remove the forced nested dark-mode styling from the Plus pricing card
- center the plans intro copy so VitePress markdown paragraph margins cannot override it
- use explicit CSS variable color utilities for card surfaces and CTAs after the Tailwind 4 migration

## Verification
- `corepack yarn build` in `.web`
- captured local light/dark screenshots for `/plans`:
  - `/tmp/connect-plans-screens/after-light.png`
  - `/tmp/connect-plans-screens/after-dark.png`

## Regression notes
- likely exposed by `dd6de454e7b2bb5bd8a4171ee74e5f1db1673e74` (`docs: announce managed Bedrock support (#97)`) when docs moved to Tailwind 4
- original fragile plans styles came from `6e200ac6f6ae6ba33a4e1907424bfa3abe0f98f3` (`docs: Introduce Pricing Plans page (#45)`) with hard-coded `dark` and `bg-red-950` on the Plus card