### PR TITLE
docs: clarify Bedrock and compatibility matrices

### DIFF
--- a/.web/docs/guide/bedrock.md
+++ b/.web/docs/guide/bedrock.md
@@ -9,16 +9,16 @@ Connect lets Bedrock players join connected endpoints through the same public ad
 For Connect-routed players, Bedrock translation is handled by the Connect edge before traffic reaches your connector.
 That means the usual Connect setup stays the same for Paper/Spigot, Velocity, BungeeCord, and Gate connectors.
 
-## Which Setup Do I Need?
+## Support Behavior Matrix
 
-| Setup | What to configure | Who handles Bedrock translation |
-| --- | --- | --- |
-| Connect Plugin on Paper/Spigot, Velocity, or BungeeCord | Install and run the Connect plugin normally | Connect edge |
-| Standard Gate with `connect` enabled | Enable Connect normally | Connect edge for Connect-routed players |
-| Standard Gate with direct Bedrock clients | Add `bedrock: true` to Gate | Your Gate instance |
-| Standard Gate with both Connect and direct Bedrock | Enable Connect and `bedrock: true` | Connect edge for Connect addresses, Gate for direct Bedrock address |
-| Gate Lite behind Connect | Configure Gate Lite as a Java connector | Connect edge for Connect-routed Bedrock players |
-| Gate Lite as a direct Bedrock listener | Use standard Gate instead | Not supported in Gate Lite |
+| Setup | What to configure | Bedrock translation | Backend Floodgate API | Online-mode and account behavior | Custom domain coexistence |
+| --- | --- | --- | --- | --- | --- |
+| Connect-managed Bedrock with Paper/Velocity/Bungee connector | Install the Connect plugin normally. Do not enable backend Gate `bedrock: true` for Connect-managed Bedrock. | Connect edge | Supported only for the compatibility data Connect forwards. If a plugin expects a local Floodgate/Geyser runtime, collect logs and plugin names. | Java online-mode stays on the Java path. Bedrock players may be rejected by servers that require a linked Java account. | Supported. Bedrock and Java can use the same endpoint subdomain or custom domain. |
+| Connect-managed Bedrock with standard Gate `connect` enabled | Enable the Gate Connect connector normally. Do not add local Bedrock settings only for Connect players. | Connect edge | Same Connect-managed compatibility behavior as plugin connectors. | Treat kicks as Connect-managed first, then Gate/backend auth. Do not switch the backend to offline mode unless the whole topology requires it. | Supported. Connect addresses and custom domains stay shared. |
+| self-hosted Gate direct Bedrock | Add `bedrock: true` to the standard Gate instance that Bedrock clients join directly. | Your Gate instance | Local Gate/Floodgate behavior belongs to that Gate setup, not Connect-managed Bedrock. | Follow Gate's direct Bedrock and account-linking requirements. | Use a separate direct Bedrock hostname or port unless you intentionally route that hostname outside Connect. |
+| Standard Gate with both Connect and direct Bedrock | Enable Connect for Connect addresses and `bedrock: true` only for the separate direct Bedrock listener. | Connect edge for Connect addresses, Gate for the direct Bedrock address | Diagnose by join address. Connect-managed joins use Connect compatibility data; direct joins use local Gate behavior. | Ask which address the player used before changing online-mode or linking settings. | Supported when DNS clearly separates Connect-routed names from direct Gate names. |
+| Gate Lite behind Connect | Configure Gate Lite as a Java connector behind Connect. | Connect edge | Treat backend Floodgate API reports as Connect-managed compatibility reports. | Gate Lite is not the direct Bedrock authority; keep auth decisions in the backend/proxy path. | Supported for Connect-routed endpoint domains. |
+| Gate Lite as a direct Bedrock listener | Use standard Gate instead. | Not supported in Gate Lite | Not supported. | Not supported. | Not supported. |
 
 ## Connect-Routed Bedrock
 
@@ -33,6 +33,9 @@ You do not need to:
 - set `bedrock: true` in your backend Gate just for Connect players
 
 This applies to the Connect Java plugin and to Gate used as a Connect connector.
+
+Do not enable backend Gate `bedrock: true` for Connect-managed Bedrock. That setting is for self-hosted Gate direct
+Bedrock listeners and can create a second Bedrock path that support then has to diagnose separately.
 
 ## Direct Self-Hosted Gate Bedrock
 
@@ -63,3 +66,33 @@ by the target server.
 
 If you are troubleshooting online-mode behavior, first identify whether the player joined through a Connect address or a
 direct self-hosted Gate Bedrock address. The required configuration is different for those two paths.
+
+Keep online-mode decisions tied to the whole Java forwarding topology. A Connect-managed Bedrock report is not, by
+itself, a reason to disable online-mode or allow offline-mode players on the backend.
+
+## Backend Floodgate API Compatibility
+
+Some backend plugins query Floodgate-style player metadata to decide whether a player is from Bedrock, linked to Java,
+or allowed past a login step. Connect-managed Bedrock forwards compatibility data for supported paths, but servers can
+still fail when a plugin assumes it is talking to a local Floodgate/Geyser installation.
+
+When Floodgate-dependent behavior fails, ask for:
+
+- the exact join address the Bedrock player used
+- connector type and version
+- backend server type and version
+- Floodgate, Geyser, auth, or login plugin names and versions
+- the kick text and logs from Connect, the connector, proxy, and backend around the same timestamp
+- whether the same player succeeds through a direct self-hosted Gate Bedrock address, if one exists
+
+Do not recommend installing backend Geyser/Floodgate or enabling Gate `bedrock: true` unless the user wants to operate a
+separate self-hosted Gate direct Bedrock path.
+
+## Discord support response draft
+
+> Connect-managed Bedrock is separate from self-hosted Gate Bedrock. If your player joins through
+> `<endpoint>.play.minekube.net`, `minekube.net`, or a custom domain attached to the endpoint, do not enable backend Gate
+> `bedrock: true` just for that player. Connect handles Bedrock translation at the edge. If a Floodgate-dependent plugin
+> rejects the player, send the join hostname, connector type/version, backend type/version, Floodgate/Geyser/auth plugin
+> versions, the exact kick text, and logs from the Connect connector/proxy/backend at the same timestamp. Only use
+> `bedrock: true` when Bedrock clients connect directly to your own standard Gate instance outside Connect.

--- a/.web/docs/guide/compatibility.md
+++ b/.web/docs/guide/compatibility.md
@@ -19,7 +19,7 @@ the combinations that most often need extra care.
 | Component | Risk | Recommended support response |
 | --- | --- | --- |
 | Velocity snapshots | Medium | Ask for the exact Velocity build and Connect plugin version. Reproduce on a stable Velocity build if packet or login behavior changed. |
-| FastLogin, AuthMe, NLogin, and similar login plugins | Medium to high | Ask whether the server is online-mode, offline-mode, or mixed. Confirm whether the player joined through Connect, TCPShield, direct proxy, or direct backend. |
+| FastLogin, AuthMe, NLogin, and similar login plugins | Medium to high | Ask whether the server is online-mode, offline-mode, or mixed. Confirm whether the player joined through Connect, TCPShield, direct proxy, or direct backend. Do not treat a Connect-managed Bedrock report as a reason to enable direct Gate Bedrock. |
 | MultiProxySync and profile/skin sync plugins | Medium | Check whether UUID/profile data is expected from the proxy, backend, or plugin. Compare behavior between the direct proxy path and the Connect path. |
 | TCPShield in front of Java while Connect handles Bedrock | Medium | Treat as two ingress paths. Ask which hostname the player used and whether forwarding is configured consistently on both paths. |
 | Backend direct public access | High | Players can bypass forwarding and authentication assumptions. Recommend closing direct backend access or documenting it as a separate path. |
@@ -30,9 +30,16 @@ the combinations that most often need extra care.
 | --- | --- | --- |
 | Vanilla-compatible Paper or Spigot | Low | Best supported path. |
 | Forge or NeoForge behind a supported proxy | Medium | Test login and plugin-message behavior. Some modded handshakes assume a direct client-to-server path. |
-| Arclight, Ketting, Mohist, Magma, and other hybrid servers | High | Hybrid server internals vary. Ask for exact server type/version and logs before recommending a Connect or proxy setting. |
-| Fabric servers with proxy support | Medium | Verify the proxy forwarding plugin/mod expected by the backend. |
+| Arclight/Ketting/Forge hybrids, Mohist, Magma, and similar servers | High | Hybrid server internals vary. Ask for exact server type/version and logs before recommending a Connect or proxy setting. |
+| Fabric servers with FabricProxy-Lite | Medium | Verify the proxy forwarding mod expected by the backend is installed, enabled, and configured with the same forwarding secret as the proxy. |
+| Fabric servers with CrossStitch | Medium | CrossStitch is required when the Fabric backend needs Velocity modern forwarding support that FabricProxy-Lite alone does not provide. It is recommended when users report login/profile mismatch with Velocity-style forwarding. Verify by checking the backend log for the forwarding mod loading and by confirming direct Velocity-to-backend login works before adding Connect. |
+| Polymer and server-side mod stacks | Medium | Usually compatible when the server remains vanilla-protocol compatible. Ask whether the issue also occurs without Connect and collect the mod list when resource-pack, profile, or login behavior differs. |
+| NeoForge 1.21.x / Proxy-Compatible-Forge through Connect | Product investigation | Classify as a Connect compatibility investigation, not generic local Gate misconfiguration. Preserve the join address, Connect plugin version, proxy type/version, NeoForge version, Proxy-Compatible-Forge version, exact kick text, and logs from the status/login/configuration phases. Track product regression coverage in [connect#111](https://github.com/minekube/connect/issues/111). |
 | Modpacks requiring custom client handshakes | Medium to high | Confirm whether the proxy and backend both support the required handshake. |
+
+Use a product bug when a NeoForge or Forge-compatible path works through the same proxy without Connect but fails only
+through Connect. The report should focus on whether Connect preserves the status, login, plugin-message, and
+configuration-phase metadata the backend forwarding mod expects.
 
 ## Bedrock and Account Linking
 
@@ -46,6 +53,9 @@ If a Bedrock player can ping but cannot join:
 - check whether the kick is from the Connect edge, the connector, the proxy, or the backend
 - avoid recommending backend Geyser, Floodgate, UDP port opening, or `bedrock: true` unless the user wants direct
   Bedrock clients to hit their own standard Gate instance
+
+For backend Floodgate API issues, use the [Bedrock support matrix](/guide/bedrock#support-behavior-matrix) and collect
+plugin versions before recommending topology changes.
 
 ## What to Ask For
 
@@ -61,4 +71,3 @@ For compatibility reports, ask for the smallest useful set of facts:
 
 That information usually tells support whether the issue belongs to Connect ingress, proxy forwarding, backend auth,
 modded handshake compatibility, or local server configuration.
-

--- a/.web/package.json
+++ b/.web/package.json
@@ -5,6 +5,7 @@
   "author": "Minekube",
   "scripts": {
     "dev": "vitepress dev docs",
+    "check:docs": "node scripts/check-docs.mjs",
     "build": "vitepress build docs",
     "serve": "vitepress serve docs"
   },

--- a/.web/scripts/check-docs.mjs
+++ b/.web/scripts/check-docs.mjs
@@ -1,0 +1,49 @@
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+
+const root = new URL('..', import.meta.url)
+
+function readDoc(path) {
+  return readFileSync(resolve(root.pathname, path), 'utf8')
+}
+
+function assertIncludes(content, expected, file) {
+  if (!content.includes(expected)) {
+    throw new Error(`${file} is missing required docs coverage: ${expected}`)
+  }
+}
+
+function assertAll(file, required) {
+  const content = readDoc(file)
+
+  for (const expected of required) {
+    assertIncludes(content, expected, file)
+  }
+}
+
+assertAll('docs/guide/bedrock.md', [
+  'Connect-managed Bedrock',
+  'self-hosted Gate direct Bedrock',
+  'backend Floodgate API',
+  'online-mode',
+  'custom domain',
+  'Gate Lite',
+  'Paper/Velocity/Bungee connector',
+  'Do not enable backend Gate `bedrock: true` for Connect-managed Bedrock',
+  'Discord support response draft',
+])
+
+assertAll('docs/guide/compatibility.md', [
+  'Velocity snapshots',
+  'NLogin',
+  'AuthMe',
+  'FastLogin',
+  'Arclight/Ketting/Forge hybrids',
+  'FabricProxy-Lite',
+  'CrossStitch',
+  'Polymer',
+  'NeoForge 1.21.x / Proxy-Compatible-Forge through Connect',
+  'Connect compatibility investigation',
+])
+
+console.log('Docs content assertions passed.')


### PR DESCRIPTION
## Summary\n- expand the Bedrock support matrix to separate Connect-managed Bedrock from self-hosted Gate direct Bedrock, backend Floodgate API behavior, online-mode constraints, Gate Lite, and custom domain coexistence\n- expand the compatibility matrix for Velocity snapshots, login plugins, Fabric forwarding mods, Polymer/server-side mods, hybrids, and NeoForge 1.21.x / Proxy-Compatible-Forge through Connect\n- add a docs content assertion script so required matrix entries are checked before docs build\n\n## Verification\n- RED: `corepack yarn check:docs` failed before docs edits with `docs/guide/bedrock.md is missing required docs coverage: Connect-managed Bedrock`\n- GREEN: `corepack yarn check:docs`\n- `corepack yarn build`\n- `make test`\n\n## Links\n- Closes minekube/moxy#357\n- Closes minekube/moxy#358\n- NeoForge product investigation/regression target: minekube/connect#111\n\n## Notes\n- I did not add support-bot fixture coverage because this repository does not contain support-bot code or fixtures. The new docs assertion covers the available docs surface in this repo.