### PR TITLE
Fix blog RSS feed links

### DIFF
--- a/.web/docs/.vitepress/theme/components/posts/Article.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Article.vue
@@ -81,7 +81,7 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
         <div class="pt-5">
           <a
             class="inline-flex items-center rounded-md border border-orange-500/40 px-3 py-2 font-semibold text-orange-600 hover:border-orange-500 hover:text-orange-700 dark:text-orange-300 dark:hover:text-orange-200"
-            href="/feed.rss"
+            href="https://connect.minekube.com/feed.rss"
             aria-label="Subscribe to The Minekube Blog RSS feed"
           >
             Subscribe by RSS

--- a/.web/docs/.vitepress/theme/components/posts/Home.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Home.vue
@@ -14,7 +14,7 @@ const { frontmatter } = useData()
         <p class="mt-2 text-lg leading-8 text-[--vp-c-text-2]">{{ frontmatter.subtext }}</p>
         <div class="mt-6 flex justify-center">
           <a
-            href="/feed.rss"
+            href="https://connect.minekube.com/feed.rss"
             class="inline-flex items-center rounded-md bg-[--vp-button-brand-bg] px-4 py-2.5 text-sm font-semibold text-[--vp-button-brand-text] shadow-sm hover:bg-[--vp-button-brand-hover-bg]"
             aria-label="Subscribe to The Minekube Blog RSS feed"
           >

--- a/.web/docs/.vitepress/theme/components/posts/Layout.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Layout.vue
@@ -34,7 +34,7 @@ const { page, frontmatter } = useData()
           >
           <a
             class="inline-flex items-center rounded-md border border-orange-500/40 px-3 py-2 font-semibold text-orange-600 hover:border-orange-500 hover:text-orange-700 dark:text-orange-300 dark:hover:text-orange-200"
-            href="/feed.rss"
+            href="https://connect.minekube.com/feed.rss"
             aria-label="Subscribe to The Minekube Blog RSS feed"
             >RSS<span class="hidden sm:inline">&nbsp;Feed</span></a
           >


### PR DESCRIPTION
## Summary
- Change visible blog RSS links from internal `/feed.rss` paths to the absolute feed URL.
- Prevent VitePress client routing from normalizing RSS clicks to `/feed.rss.html`.

## Test Plan
- `cd .web && mise exec node@24 -- corepack yarn check:docs`
- `cd .web && mise exec node@24 -- corepack yarn build`
- Parsed generated `feed.rss` and `sitemap.xml` with Python XML parser.
- Verified generated blog pages contain `href="https://connect.minekube.com/feed.rss"` and no `/feed.rss.html` references.
