### PR TITLE
Fix RSS link click routing

### DIFF
--- a/.web/docs/.vitepress/theme/components/posts/Article.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Article.vue
@@ -82,6 +82,7 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
           <a
             class="inline-flex items-center rounded-md border border-orange-500/40 px-3 py-2 font-semibold text-orange-600 hover:border-orange-500 hover:text-orange-700 dark:text-orange-300 dark:hover:text-orange-200"
             href="https://connect.minekube.com/feed.rss"
+            @click.stop
             aria-label="Subscribe to The Minekube Blog RSS feed"
           >
             Subscribe by RSS

--- a/.web/docs/.vitepress/theme/components/posts/Home.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Home.vue
@@ -16,6 +16,7 @@ const { frontmatter } = useData()
           <a
             href="https://connect.minekube.com/feed.rss"
             class="inline-flex items-center rounded-md bg-[--vp-button-brand-bg] px-4 py-2.5 text-sm font-semibold text-[--vp-button-brand-text] shadow-sm hover:bg-[--vp-button-brand-hover-bg]"
+            @click.stop
             aria-label="Subscribe to The Minekube Blog RSS feed"
           >
             Subscribe by RSS

--- a/.web/docs/.vitepress/theme/components/posts/Layout.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Layout.vue
@@ -35,6 +35,7 @@ const { page, frontmatter } = useData()
           <a
             class="inline-flex items-center rounded-md border border-orange-500/40 px-3 py-2 font-semibold text-orange-600 hover:border-orange-500 hover:text-orange-700 dark:text-orange-300 dark:hover:text-orange-200"
             href="https://connect.minekube.com/feed.rss"
+            @click.stop
             aria-label="Subscribe to The Minekube Blog RSS feed"
             >RSS<span class="hidden sm:inline">&nbsp;Feed</span></a
           >


### PR DESCRIPTION
## Summary
- Stop VitePress from intercepting visible RSS feed clicks.
- Keep the feed href as `https://connect.minekube.com/feed.rss`, but add `@click.stop` so native browser navigation opens the RSS XML instead of SPA-routing to `/feed.rss.html`.

## Test Plan
- `cd .web && mise exec node@24 -- corepack yarn check:docs`
- `cd .web && mise exec node@24 -- corepack yarn build`
- Browser-validated current production `https://connect.minekube.com/blog/` still routes RSS clicks to `/feed.rss.html` before this fix.
- Browser-validated local built output: clicking RSS on `/blog/` navigates to `https://connect.minekube.com/feed.rss`.
- Browser-validated local built output: clicking RSS on `/blog/minekube-browser-apis-agents.html` navigates to `https://connect.minekube.com/feed.rss`.
- Verified generated pages contain no `/feed.rss.html` references.
