### PR TITLE
Fix RSS buttons bypass router

### DIFF
--- a/.web/docs/.vitepress/theme/components/posts/Article.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Article.vue
@@ -17,6 +17,10 @@ function findCurrentIndex() {
 const date = computed(() => posts[findCurrentIndex()].date)
 const nextPost = computed(() => posts[findCurrentIndex() - 1])
 const prevPost = computed(() => posts[findCurrentIndex() + 1])
+
+function openRssFeed() {
+  window.location.assign('https://connect.minekube.com/feed.rss')
+}
 </script>
 
 <template>
@@ -79,14 +83,14 @@ const prevPost = computed(() => posts[findCurrentIndex() + 1])
           <a class="link" href="/blog/">← Back to the blog</a>
         </div>
         <div class="pt-5">
-          <a
+          <button
+            type="button"
             class="inline-flex items-center rounded-md border border-orange-500/40 px-3 py-2 font-semibold text-orange-600 hover:border-orange-500 hover:text-orange-700 dark:text-orange-300 dark:hover:text-orange-200"
-            href="https://connect.minekube.com/feed.rss"
-            @click.stop
+            @click="openRssFeed"
             aria-label="Subscribe to The Minekube Blog RSS feed"
           >
             Subscribe by RSS
-          </a>
+          </button>
         </div>
       </footer>
     </div>

--- a/.web/docs/.vitepress/theme/components/posts/Home.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Home.vue
@@ -4,6 +4,10 @@ import { useData } from 'vitepress'
 import JoinUs from "../positions/JoinUs.vue";
 
 const { frontmatter } = useData()
+
+function openRssFeed() {
+  window.location.assign('https://connect.minekube.com/feed.rss')
+}
 </script>
 
 <template>
@@ -13,14 +17,14 @@ const { frontmatter } = useData()
         <h2 class="text-3xl font-bold tracking-tight text-[--vp-c-text-1] sm:text-4xl">{{ frontmatter.title }}</h2>
         <p class="mt-2 text-lg leading-8 text-[--vp-c-text-2]">{{ frontmatter.subtext }}</p>
         <div class="mt-6 flex justify-center">
-          <a
-            href="https://connect.minekube.com/feed.rss"
+          <button
+            type="button"
             class="inline-flex items-center rounded-md bg-[--vp-button-brand-bg] px-4 py-2.5 text-sm font-semibold text-[--vp-button-brand-text] shadow-sm hover:bg-[--vp-button-brand-hover-bg]"
-            @click.stop
+            @click="openRssFeed"
             aria-label="Subscribe to The Minekube Blog RSS feed"
           >
             Subscribe by RSS
-          </a>
+          </button>
         </div>
       </div>
       <div class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">

--- a/.web/docs/.vitepress/theme/components/posts/Layout.vue
+++ b/.web/docs/.vitepress/theme/components/posts/Layout.vue
@@ -6,6 +6,10 @@ import NotFound from './NotFound.vue'
 import {gitHubLink} from "../../../../shared";
 
 const { page, frontmatter } = useData()
+
+function openRssFeed() {
+  window.location.assign('https://connect.minekube.com/feed.rss')
+}
 </script>
 
 <template>
@@ -32,12 +36,12 @@ const { page, frontmatter } = useData()
             rel="noopener"
             ><span class="hidden sm:inline">GitHub </span>Source</a
           >
-          <a
+          <button
+            type="button"
             class="inline-flex items-center rounded-md border border-orange-500/40 px-3 py-2 font-semibold text-orange-600 hover:border-orange-500 hover:text-orange-700 dark:text-orange-300 dark:hover:text-orange-200"
-            href="https://connect.minekube.com/feed.rss"
-            @click.stop
+            @click="openRssFeed"
             aria-label="Subscribe to The Minekube Blog RSS feed"
-            >RSS<span class="hidden sm:inline">&nbsp;Feed</span></a
+            >RSS<span class="hidden sm:inline">&nbsp;Feed</span></button
           >
           <a
             class="hover:text-gray-700 dark:hover:text-gray-200"


### PR DESCRIPTION
## Summary
- change visible RSS feed controls from anchors to buttons
- navigate to the canonical RSS URL with window.location so VitePress cannot rewrite the click to /feed.rss.html

## Test plan
- mise exec node@24 -- corepack yarn check:docs
- mise exec node@24 -- corepack yarn build
- browser-tested local static build:
  - /blog/ RSS control clicked through to https://connect.minekube.com/feed.rss
  - /blog/minekube-browser-apis-agents.html RSS control clicked through to https://connect.minekube.com/feed.rss

## Production regression
- current production still routes RSS clicks from /blog/ and the article page to /feed.rss.html even though the href is canonical