### PR TITLE
Document Bedrock identity rollout

### DIFF
--- a/.web/docs/guide/bedrock.md
+++ b/.web/docs/guide/bedrock.md
@@ -81,6 +81,52 @@ direct self-hosted Gate Bedrock address. The required configuration is different
 Keep online-mode decisions tied to the whole Java forwarding topology. A Connect-managed Bedrock report is not, by
 itself, a reason to disable online-mode or allow offline-mode players on the backend.
 
+Connect-managed Bedrock identity uses official Microsoft/Xbox Bedrock authentication at the Connect edge. It is not a
+Minekube password system, it is not backend Geyser authentication, and it is not the same thing as allowing generic
+offline-mode Java players. The connector can enforce the Bedrock identity that Connect already verified, while Java
+online-mode players continue to use the normal Java session path.
+
+## Bedrock Identity Enforcement
+
+For Connect-routed Bedrock, the Connect edge verifies the player's Microsoft/Xbox Bedrock identity and signs a short-lived
+identity envelope before forwarding the session to your connector. The Connect Java Plugin can then verify that envelope
+before the player reaches the backend.
+
+The signed identity contains the Bedrock XUID, username, policy, issue time, and expiry time. Newer connectors also bind
+the identity to the endpoint and organization that the player joined. This prevents a signed identity captured for one
+endpoint from being replayed against another endpoint in a different organization.
+
+Configure the connector with `bedrock-identity` when you want the backend to reject unsigned or invalid Connect-managed
+Bedrock sessions:
+
+::: code-group
+```yaml [plugins/connect/config.yml]
+bedrock-identity:
+  enforcement: warn
+  metadata-url: "https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json"
+  metadata-cache-seconds: 300
+  public-key: ""
+  public-keys: []
+  expected-policy: "bedrock-xuid"
+```
+:::
+
+Use `warn` first. In warn mode, invalid or missing identities are logged but the player is not rejected. After logs show
+that expected Bedrock joins carry valid identities, switch to `require`.
+
+Use `metadata-url` for normal production rollouts. It lets the connector fetch the current Ed25519 verifier key and the
+previous verifier keys that remain valid during key rotation. Static `public-key` and `public-keys` are useful for
+self-hosted, staged, or emergency rollouts. The key metadata is cacheable; keep `metadata-cache-seconds` aligned with the
+HTTP cache time served by the metadata endpoint.
+
+The key metadata endpoint is public and contains verifier public keys only:
+
+```text
+/.well-known/minekube-connect/bedrock-identity-keys.json
+```
+
+It must never expose private keys, signed player identity envelopes, access tokens, or player-specific data.
+
 ## Backend Floodgate API Compatibility
 
 Some backend plugins query Floodgate-style player metadata to decide whether a player is from Bedrock, linked to Java,
@@ -95,9 +141,16 @@ When Floodgate-dependent behavior fails, ask for:
 - Floodgate, Geyser, auth, or login plugin names and versions
 - the kick text and logs from Connect, the connector, proxy, and backend around the same timestamp
 - whether the same player succeeds through a direct self-hosted Gate Bedrock address, if one exists
+- whether `bedrock-identity.enforcement` is `disabled`, `warn`, or `require`
+- Bedrock identity warnings such as missing envelope, invalid signature, expired identity, replayed nonce, policy
+  mismatch, endpoint mismatch, or organization mismatch
 
 Do not recommend installing backend Geyser/Floodgate or enabling Gate `bedrock: true` unless the user wants to operate a
 separate self-hosted Gate direct Bedrock path.
+
+Do not ask users to paste signed Bedrock identity envelopes, private keys, account tokens, or full player profile dumps
+into public support channels. The useful support data is the join address, connector version, endpoint ownership, relevant
+timestamps, sanitized logs, and the exact rejection reason.
 
 ## Discord support response draft
 

--- a/.web/docs/guide/connectors/plugin.md
+++ b/.web/docs/guide/connectors/plugin.md
@@ -51,3 +51,24 @@ auth/session handling on supported platforms.
 Passthrough/AuthSession is planned for setups where the backend or proxy needs to run its own online-mode authentication
 for Connect-routed players. That includes topologies such as `Connect -> Gate Lite -> online-mode backend`, which are
 not supported today through Gate Lite configuration alone.
+
+## Bedrock Identity
+
+Connect-managed Bedrock is handled at the Connect edge. The plugin can verify the Bedrock identity that Connect already
+checked before forwarding the player to Paper, Velocity, or BungeeCord.
+
+::: code-group
+```yaml [plugins/connect/config.yml]
+bedrock-identity:
+  enforcement: warn
+  metadata-url: "https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json"
+  metadata-cache-seconds: 300
+  public-key: ""
+  public-keys: []
+  expected-policy: "bedrock-xuid"
+```
+:::
+
+Start with `enforcement: warn`, review connector logs for Bedrock joins, then switch to `require` when the expected joins
+carry valid identities. See the [Bedrock support guide](/guide/bedrock#bedrock-identity-enforcement) for the rollout and
+support checklist.

--- a/.web/docs/guide/offline-mode.md
+++ b/.web/docs/guide/offline-mode.md
@@ -10,6 +10,10 @@ There are also many public offline-mode servers that allow players to join witho
 
 Offline mode servers and unauthenticated players are often referred to as _cracked_ servers and players.
 
+This is different from Connect-managed Bedrock identity. Bedrock players who join through Connect can be authenticated
+with official Microsoft/Xbox Bedrock auth and still travel through a Java connector. That trusted Bedrock/XUID path does
+not require allowing arbitrary offline-mode Java players.
+
 ## Joining the [Connect Browser Hub](/guide/advertising#browser-hub)
 
 To join the Browser Hub as a cracked player, you can use `cracked.minekube.net` to join the [Connect Network](/guide/#the-connect-network).
@@ -31,3 +35,7 @@ allow-offline-mode-players: true
 
 Offline-mode player connections are not encrypted between the player and the [Connect Network](/guide/#the-connect-network) edge.
 Player connections are always encrypted between the Connect edge and [Connect Endpoints](/guide/#connect-endpoints) - thanks to [Connect Tunnels](/guide/tunnels).
+
+Do not enable `allow-offline-mode-players` just because a Bedrock player is joining through Connect. Use the
+[Bedrock support guide](/guide/bedrock) to decide whether the player is on the Connect-managed Bedrock path, a direct
+self-hosted Gate Bedrock path, or a real offline-mode Java path.

--- a/.web/scripts/check-docs.mjs
+++ b/.web/scripts/check-docs.mjs
@@ -32,7 +32,23 @@ assertAll('docs/guide/bedrock.md', [
   'Do not enable backend Gate `bedrock: true` for Connect-managed Bedrock',
   'use the normal Bedrock port `19132`',
   'It does not mean you need to open UDP `19132`',
+  'official Microsoft/Xbox Bedrock authentication',
+  'Bedrock Identity Enforcement',
+  'metadata-url',
+  'endpoint and organization',
   'Discord support response draft',
+])
+
+assertAll('docs/guide/offline-mode.md', [
+  'Connect-managed Bedrock identity',
+  'official Microsoft/Xbox Bedrock auth',
+  'Do not enable `allow-offline-mode-players` just because a Bedrock player is joining through Connect',
+])
+
+assertAll('docs/guide/connectors/plugin.md', [
+  'Bedrock Identity',
+  'metadata-url',
+  'enforcement: warn',
 ])
 
 assertAll('docs/guide/compatibility.md', [


### PR DESCRIPTION
## Summary
- document Connect-managed Bedrock identity enforcement and official Microsoft/Xbox auth boundaries
- document verifier metadata, key rotation, endpoint/org scope, and safe support diagnostics
- clarify that trusted Bedrock/XUID identity is distinct from generic offline-mode Java access
- add the connector `bedrock-identity` config surface to the plugin guide

## Verification
- `mise exec node@24 -- corepack yarn check:docs`
- `mise exec node@24 -- corepack yarn build`
- `git diff --check`

Tracks private rollout issue #424.