### PR TITLE
docs: fix Bedrock metadata URL

### DIFF
--- a/.web/docs/guide/bedrock.md
+++ b/.web/docs/guide/bedrock.md
@@ -103,7 +103,7 @@ Bedrock sessions:
 ```yaml [plugins/connect/config.yml]
 bedrock-identity:
   enforcement: warn
-  metadata-url: "https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json"
+  metadata-url: "https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json"
   metadata-cache-seconds: 300
   public-key: ""
   public-keys: []

--- a/.web/docs/guide/connectors/plugin.md
+++ b/.web/docs/guide/connectors/plugin.md
@@ -61,7 +61,7 @@ checked before forwarding the player to Paper, Velocity, or BungeeCord.
 ```yaml [plugins/connect/config.yml]
 bedrock-identity:
   enforcement: warn
-  metadata-url: "https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json"
+  metadata-url: "https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json"
   metadata-cache-seconds: 300
   public-key: ""
   public-keys: []


### PR DESCRIPTION
## Intent

Fix minekube/connect issue #124 as a docs-only lane, separate from Moxy PR #460. The production docs currently direct operators to https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json, but live recheck on 2026-07-08 showed that docs-domain URL returns HTTP 404 text/html from the VitePress/Cloudflare Pages site. The working metadata service URL documented in the issue is https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json, which live recheck showed returns HTTP 200 application/json. The repo search found the stale Bedrock metadata URL only in docs examples, with no owned runtime route requiring the vanity docs-domain URL to work. Keep the change docs-only and limited to .web/docs/guide/bedrock.md and .web/docs/guide/connectors/plugin.md; do not perform Cloudflare, DNS, GitOps, Moxy, or production route mutations. Validation already run before this gate: in .web, mise exec node@24 -- corepack yarn check:docs passed, mise exec node@24 -- corepack yarn build passed with only non-blocking VitePress warnings, and rg verified both edited files contain the connect-api URL while the stale full connect.minekube.com/.well-known metadata URL is absent.

## What Changed

- Updated the Bedrock identity metadata URL in the Bedrock guide example to use `https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json`.
- Applied the same metadata URL correction to the connector plugin guide’s Bedrock identity configuration example.

## Risk Assessment

✅ Low: The branch is a narrowly scoped docs-only change replacing two stale metadata endpoint examples, with no remaining stale full URL references found in the reviewed repo search scope.

## Testing

Prior context said docs checks had already passed before this gate; I independently reran the relevant docs validation after installing locked dependencies, built and served the VitePress site, captured screenshots of both changed docs pages, verified the new live API endpoint returns JSON while the old docs-domain URL returns 404 HTML, confirmed the built rendered pages include only the new URL, and ended with no actionable failures.

- Evidence: Rendered Bedrock support docs config block (local file: <code>/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KX0PHXBTX4QN3YTZZHDJR0W3/bedrock-identity-rendered.png</code>)
- Evidence: Rendered plugin connector docs config block (local file: <code>/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KX0PHXBTX4QN3YTZZHDJR0W3/plugin-bedrock-identity-rendered.png</code>)
<details>
<summary>Evidence: Live endpoint status comparison</summary>

<code>New metadata endpoint&#10;status=200&#10;content_type=application/json&#10;url=https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json&#10;&#10;Old docs-domain metadata endpoint&#10;status=404&#10;content_type=text/html; charset=utf-8&#10;url=https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json</code>

```text
New metadata endpoint
status=200
content_type=application/json
url=https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json

Old docs-domain metadata endpoint
status=404
content_type=text/html; charset=utf-8
url=https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json
```
</details>
<details>
<summary>Evidence: Rendered built docs URL check</summary>

<code>Rendered built docs URL check&#10;/guide/bedrock.html status=200 content_type=text/html;charset=utf-8&#10;/guide/bedrock.html new-url occurrences: 1&#10;/guide/bedrock.html old-url occurrences: 0&#10;/guide/connectors/plugin.html status=200 content_type=text/html;charset=utf-8&#10;/guide/connectors/plugin.html new-url occurrences: 1&#10;/guide/connectors/plugin.html old-url occurrences: 0</code>

```text
Rendered built docs URL check
/guide/bedrock.html status=200 content_type=text/html;charset=utf-8
/guide/bedrock.html new-url occurrences: 1
/guide/bedrock.html old-url occurrences: 0
/guide/connectors/plugin.html status=200 content_type=text/html;charset=utf-8
/guide/connectors/plugin.html new-url occurrences: 1
/guide/connectors/plugin.html old-url occurrences: 0
```
</details>
<details>
<summary>Evidence: New endpoint JSON shape</summary>

<code>{&#10;&#34;issuer&#34;: &#34;minekube-connect&#34;,&#10;&#34;algorithm&#34;: &#34;Ed25519&#34;,&#10;&#34;has_current_public_key&#34;: true,&#10;&#34;previous_public_keys&#34;: 0,&#10;&#34;cache_max_age_seconds&#34;: 300&#10;}</code>

```text
{
  "issuer": "minekube-connect",
  "algorithm": "Ed25519",
  "has_current_public_key": true,
  "previous_public_keys": 0,
  "cache_max_age_seconds": 300
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 80e38b37496ef9f9207d568fdbcde32241b037a0..6e0aefa3c221951ae797af9a9a5c2388505eb571`
- `rg -n "connect(-api)?\.minekube\.com/.well-known/minekube-connect/bedrock-identity-keys\.json|bedrock-identity-keys\.json|metadata-url" .web/docs`
- <code>Initial `mise exec node@24 -- corepack yarn check:docs` showed dependencies were not installed in the isolated worktree; fixed setup with `mise exec node@24 -- corepack yarn install --immutable`.</code>
- `mise exec node@24 -- corepack yarn check:docs`
- `mise exec node@24 -- corepack yarn build`
- <code>`curl` comparison of `https://connect-api.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json` and `https://connect.minekube.com/.well-known/minekube-connect/bedrock-identity-keys.json`, with headers/body saved to the evidence directory.</code>
- <code>`node -e` parsed the new endpoint JSON response and recorded issuer, algorithm, public-key presence, previous key count, and cache age.</code>
- <code>`mise exec node@24 -- corepack yarn serve --host 127.0.0.1 --port 4173` followed by `chrome-devtools-axi` screenshots of `/guide/bedrock#bedrock-identity-enforcement` and `/guide/connectors/plugin#bedrock-identity`.</code>
- <code>`curl http://localhost:4173/guide/bedrock.html` and `curl http://localhost:4173/guide/connectors/plugin.html` checked the built rendered HTML contains the new URL once per page and the old URL zero times.</code>
- <code>`rm -rf .web/.pnp.cjs .web/.pnp.loader.mjs .web/.yarn .web/docs/.vitepress/dist .web/docs/.vitepress/cache` cleanup, then `git status --short --ignored .web` final check.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
