### PR TITLE
fix(docs): make changelog links honest for empty releases

### DIFF
--- a/.web/AGENTS.md
+++ b/.web/AGENTS.md
@@ -55,6 +55,13 @@ Two things in those files are load-bearing, not style:
   by reading built HTML, never the markdown.
 - **The RSS link is a raw `<a>`, not a markdown link.** A markdown link to
   `/changelog.rss` fails the build's dead-link check.
+- **A release page that exists is not a build you can download.** An `Upgrade`
+  badge linking a tag with zero release assets sends readers to a dead end that
+  no dead-link check catches, because the tag URL itself returns 200. Check
+  before linking: `gh api repos/<owner>/<repo>/releases/tags/<tag> --jq
+  '[.assets[]] | length'`. If it is 0, name the closest later release that does
+  have assets and contains the change (`gh api repos/.../compare/<tag>...<newer>`
+  reporting `ahead` proves containment).
 
 `genFeed.ts` emits a second feed at `/changelog.rss` from `changelog/*.md`,
 flattening `<VPBadge>` to `<strong>` because feed readers drop unknown

--- a/.web/docs/changelog/2026-07-27.md
+++ b/.web/docs/changelog/2026-07-27.md
@@ -48,7 +48,7 @@ date: 2026-07-27
 ## July 7, 2026
 
 - <VPBadge type='tip'>Connect</VPBadge> <VPBadge type='info'>Live</VPBadge> **Connect reliability work through June and early July:** browser-hub fallback after endpoint kicks, endpoint sessions kept during server switches, authorized transfers while the current server is unavailable, cached endpoint status pings, and custom-domain routes loaded before serving. (Internal repository, no public link.)
-- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Stopping an official Fabric client now actually terminates it.** It previously reported success while leaving the Minecraft process running. The CLI installer also now includes the latest official lane. Both in [v0.3.5](https://github.com/minekube/craftless/releases/tag/v0.3.5).
+- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Stopping an official Fabric client now actually terminates it.** It previously reported success while leaving the Minecraft process running. The CLI installer also now includes the latest official lane. Both were tagged v0.3.5, which was published with no downloadable build; install [v0.3.6](https://github.com/minekube/craftless/releases/tag/v0.3.6) instead, which contains both fixes and has builds attached.
 
 ## July 4, 2026
 
@@ -58,12 +58,12 @@ date: 2026-07-27
 
 - <VPBadge type='tip'>Gate</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Config plugin messages are queued during backend login instead of dropped** ([v0.68.22](https://github.com/minekube/gate/releases/tag/v0.68.22)).
 - <VPBadge type='tip'>Connect plugin</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **The Connect plugin explains why Connect rejected its credentials** instead of reporting a bare authentication failure, in [0.7.10](https://github.com/minekube/connect-java/releases/tag/0.7.10).
-- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Three Craftless CLI and daemon fixes in [v0.3.1](https://github.com/minekube/craftless/releases/tag/v0.3.1):** the CLI defaults the daemon workspace instead of requiring one, ambiguous API help lists every matching method, and the daemon reports connection attempts it never observed.
+- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Three Craftless CLI and daemon fixes, tagged v0.3.1 — a release that has no downloadable build and cannot be repaired, so install [v0.3.6](https://github.com/minekube/craftless/releases/tag/v0.3.6), which contains them:** the CLI defaults the daemon workspace instead of requiring one, ambiguous API help lists every matching method, and the daemon reports connection attempts it never observed.
 
 ## July 1, 2026
 
 - <VPBadge type='tip'>Connect</VPBadge> <VPBadge type='info'>Live</VPBadge> **Opening a Connect endpoint tunnel could fail before the request ever reached Connect.** When the machine that received the request was not the machine holding your endpoint's session, the request was rejected upstream instead of being handed over, so tunnels and the joins that depend on them failed while the endpoint itself looked healthy. Those requests are now passed directly to the machine holding the session. Fixed and deployed on July 1. (Internal repository, no public link.)
-- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Craftless reports which Fabric runtimes it supports and refuses targets it cannot run.** Fabric runtime and loader support targets are exposed in the loader matrix, unsupported or undiscovered targets are rejected with a structured error, and a headless launch that cannot be satisfied now stops immediately instead of starting. All in [v0.3.0](https://github.com/minekube/craftless/releases/tag/v0.3.0).
+- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Craftless reports which Fabric runtimes it supports and refuses targets it cannot run.** Fabric runtime and loader support targets are exposed in the loader matrix, unsupported or undiscovered targets are rejected with a structured error, and a headless launch that cannot be satisfied now stops immediately instead of starting. All were tagged v0.3.0, a release that has no downloadable build and cannot be repaired; install [v0.3.6](https://github.com/minekube/craftless/releases/tag/v0.3.6), which contains them.
 
 ## June 30, 2026
 
@@ -72,7 +72,7 @@ date: 2026-07-27
 ## June 29, 2026
 
 - <VPBadge type='tip'>Connect plugin</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **The Connect plugin's peer-to-peer networking no longer shares Netty internals with your server,** removing a class of interference between the two, and Velocity chat sessions now survive the reconfiguration step during a Connect tunnel join. Both in [0.7.8](https://github.com/minekube/connect-java/releases/tag/0.7.8).
-- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Craftless gets a documentation site, version discovery and a screenshot API.** [v0.2.0](https://github.com/minekube/craftless/releases/tag/v0.2.0) publishes the docs site, reports which runtime versions it can run and defaults to the latest, adds an API for generated screenshot artifacts, and routes every CLI invocation through that API instead of a second code path. Earlier the same day, [v0.1.2](https://github.com/minekube/craftless/releases/tag/v0.1.2) added `latest-release` and `latest-snapshot` as Minecraft version aliases, a `--loader-version` option when creating a client, and `--help` for each command group.
+- <VPBadge type='tip'>Craftless</VPBadge> <VPBadge type='warning'>Upgrade</VPBadge> **Craftless gets a documentation site, version discovery and a screenshot API.** v0.2.0 publishes the docs site, reports which runtime versions it can run and defaults to the latest, adds an API for generated screenshot artifacts, and routes every CLI invocation through that API instead of a second code path; that release has no downloadable build and cannot be repaired, so install [v0.3.6](https://github.com/minekube/craftless/releases/tag/v0.3.6), which contains all of it. Earlier the same day, [v0.1.2](https://github.com/minekube/craftless/releases/tag/v0.1.2) added `latest-release` and `latest-snapshot` as Minecraft version aliases, a `--loader-version` option when creating a client, and `--help` for each command group.
 
 ## June 28, 2026
 


### PR DESCRIPTION
## Intent

Make the live connect.minekube.com changelog page honest about releases that genuinely cannot be downloaded, so no badge or link invites a user to fetch a build that 404s. This is the final step of a fleet-wide release-repair programme; an earlier correction (PR #132) already added a page-wide caveat that a release may not have a build attached, so the remaining job was strictly to fix entries that still point an Upgrade badge at a specific undownloadable release.

Verification done before editing (all against the live GitHub API, not assumed): every release URL linked from docs/changelog/2026-07-27.md was checked for attached assets. Exactly four are empty, all craftless: v0.3.5 (deliberately left empty; v0.3.6 is the working successor) and v0.3.1, v0.3.0, v0.2.0 (permanently unrepairable - a self-invalidating release guard in the tag; documented in craftless docs/release-troubleshooting.md). Every other linked release - all gate, connect-java, vialite and geyserlite tags including geyserlite v0.4.0, which was broken and has since been repaired - has real assets and was deliberately left byte-identical.

The change: those four entries now state plainly that the named tag has no downloadable build, and point at craftless v0.3.6 instead. v0.3.6 was verified via the compare API to be strictly ahead of all four tags (ahead_by 2/16/24/53, behind_by 0), so it genuinely contains their changes, and it has three assets attached. Deliberate choices a reviewer should not flag as mistakes: the Upgrade badge is kept on all four entries because there IS a real upgrade action (install v0.3.6); the dead v0.3.5/v0.3.1/v0.3.0/v0.2.0 tag links are removed entirely rather than kept as non-download references, so no download affordance survives; no state claim or completeness claim removed by earlier corrections is reintroduced; docs/changelog/index.md is intentionally untouched because its existing bullet already covers the general case. Each entry stays on one long source line, which is load-bearing for VPBadge list items.

Verified on a cold rebuild (dist and cache removed, corepack yarn build): the built changelog HTML and the generated changelog.rss both carry the honesty text and link only v0.3.6; no craftless v0.2.0/v0.3.0/v0.3.1/v0.3.5 tag URL survives anywhere in dist. Badge count (84) and entry count (42) are unchanged, exactly 4 source lines differ. Both feeds parse as valid XML, scripts/check-docs.mjs passes, and all 55 document links in the built page and feed were fetched and returned 200 (the only non-200 is ph.minekube.com, the pre-existing PostHog analytics host from config.ts, not a document link).

Also added a short durable note to .web/AGENTS.md under the changelog section: a release page returning 200 is not proof of a downloadable build, with the gh api commands to check asset count and prove containment in a newer release. Do not merge - the PR is verified and merged by the supervising process.

## What Changed

- Updated four Craftless changelog entries for v0.3.5, v0.3.1, v0.3.0, and v0.2.0 to state that no downloadable build exists and direct users to asset-backed v0.3.6 instead.
- Added durable changelog guidance to `.web/AGENTS.md` for checking release assets and verifying that a newer release contains the tagged changes.

## Risk Assessment

✅ Low: The documentation changes are narrowly scoped, remove all four undownloadable Craftless tag links, preserve the intended upgrade path, and introduce no source-verifiable regressions.

## Testing

Cold build, docs checks, live GitHub API verification, generated HTML/RSS checks, XML parsing, 55 HTTP link checks, and browser screenshots all demonstrate the intended behavior. Transient build artifacts were removed.

- Evidence: Rendered changelog caveat (local file: <code>/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KYHG3P53XNBP2MHH1YMQTSP4/changelog-top.png</code>)
- Evidence: Rendered repaired entries (local file: <code>/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KYHG3P53XNBP2MHH1YMQTSP4/changelog-repaired.png</code>)
<details>
<summary>Evidence: Build validation evidence</summary>

```text
Cold changelog build evidence
source entries: 42
source badges: 84
generated entry badges: 84
generated feed entry badges: 42
repaired entries: v0.3.5=honest -> v0.3.6, v0.3.1=honest -> v0.3.6, v0.3.0=honest -> v0.3.6, v0.2.0=honest -> v0.3.6
old undownloadable tag URLs in generated HTML: 0
old undownloadable tag URLs in generated RSS: 0
document links checked: 55
document links HTTP 200: 55
document link failures: 0
{
  "sourceEntries": 42,
  "sourceBadges": 84,
  "generatedEntryBadges": 84,
  "generatedFeedEntryBadges": 42,
  "repaired": {
    "v0.3.5": {
      "hasHonestyText": true,
      "hasNewerLink": true,
      "hasDeadLink": false,
      "oneSourceLine": true
    },
    "v0.3.1": {
      "hasHonestyText": true,
      "hasNewerLink": true,
      "hasDeadLink": false,
      "oneSourceLine": true
    },
    "v0.3.0": {
      "hasHonestyText": true,
      "hasNewerLink": true,
      "hasDeadLink": false,
      "oneSourceLine": true
    },
    "v0.2.0": {
      "hasHonestyText": true,
      "hasNewerLink": true,
      "hasDeadLink": false,
      "oneSourceLine": true
    }
  },
  "deadTagUrlsInGeneratedHtml": [],
  "deadTagUrlsInGeneratedFeed": [],
  "honestyMentionsInHtml": [
    "v0.3.5",
    "v0.3.1",
    "v0.3.0",
    "v0.2.0"
  ],
  "honestyMentionsInFeed": [
    "v0.3.5",
    "v0.3.1",
    "v0.3.0",
    "v0.2.0"
  ],
  "documentLinks": 55,
  "documentLinksHttp200": 55,
  "documentLinkFailures": []
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `corepack yarn install --immutable`
- `corepack yarn build`
- `corepack yarn check:docs`
- `Generated HTML/RSS assertions`
- `xmllint --noout docs/.vitepress/dist/changelog.rss`
- `55 document-link HTTP checks`
- `Browser rendering and screenshots`
- `Git diff and entry-count verification`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
