### PR TITLE
feat(web): migrate docs hosting to Workers Static Assets

### DIFF
--- a/.web/.gitignore
+++ b/.web/.gitignore
@@ -1,5 +1,6 @@
 /docs/.vitepress/dist/
 /node_modules/
+/.wrangler/
 .yarn
 .pnp.*
 */.vitepress/cache/

--- a/.web/AGENTS.md
+++ b/.web/AGENTS.md
@@ -1,7 +1,8 @@
 # Connect Docs Agent Notes
 
 This package builds the public Connect documentation and blog with VitePress
-and deploys it to Cloudflare Pages at `connect.minekube.com`.
+and uses the canary-first Cloudflare Workers Static Assets deployment procedure
+in [README.md](README.md).
 
 ## Scope
 
@@ -20,7 +21,7 @@ can still be routed by the client to a `.html` path such as `/feed.rss.html`.
 When changing RSS or other static-file navigation:
 
 - Prefer a real browser click test over HTML inspection alone.
-- Verify local built output, the Cloudflare Pages preview, and production when
+- Verify local built output, the isolated Worker canary, and production when
   the task is production-facing.
 - Confirm `https://connect.minekube.com/feed.rss` and
   `https://connect.minekube.com/changelog.rss` return
@@ -76,6 +77,7 @@ Use the Node version managed by the repository tooling:
 cd .web
 mise exec node@24 -- corepack yarn check:docs
 mise exec node@24 -- corepack yarn build
+mise exec node@24 -- corepack yarn test:worker
 ```
 
 For browser verification of built docs, serve `docs/.vitepress/dist` and test
@@ -88,8 +90,11 @@ returns the home page HTML, and the hydrated result looks like a broken page.
 Do not call a production docs fix complete from a merge alone. Check each layer:
 
 - GitHub checks pass.
-- Cloudflare Pages deployment succeeds.
-- The relevant Cloudflare preview behaves correctly.
+- The `connect-docs-canary.minekube.com` Worker deployment succeeds before production is
+  considered.
+- Deploy the production custom hostname only after current validation and
+  explicit authorization.
+- The relevant Worker canary behaves correctly.
 - The production URL behaves correctly with a browser smoke test.
 
 ## Maintaining this file

--- a/.web/README.md
+++ b/.web/README.md
@@ -43,8 +43,15 @@ using any static contents hosting service.
 
 ### Deployment
 
-Our docs are deployed using [Cloudflare Pages](https://pages.cloudflare.com).
-Every commit pushed to `main` branch will automatically deploy to
-[connect.minekube.com](https://connect.minekube.com),
-and any pull requests opened will have a corresponding staging URL available in
-the pull request comments.
+Our docs are deployed as [Cloudflare Workers Static
+Assets](https://developers.cloudflare.com/workers/static-assets/). Build the
+site, deploy and validate the isolated `connect-docs-canary.minekube.com`
+canary, then deploy the production
+Worker only when the custom hostname is authorized to move:
+
+```sh
+$ yarn build
+$ yarn deploy:worker:canary
+# validate https://connect-docs-canary.minekube.com
+$ yarn deploy:worker
+```

--- a/.web/docs/public/_headers
+++ b/.web/docs/public/_headers
@@ -1,3 +1,57 @@
+/*
+  Access-Control-Allow-Origin: *
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+
+# VitePress clean URLs require an explicit HTML charset header.
+/
+  Content-Type: text/html; charset=utf-8
+
+/guide/*
+  Content-Type: text/html; charset=utf-8
+
+/changelog/*
+  Content-Type: text/html; charset=utf-8
+
+/blog/
+  Content-Type: text/html; charset=utf-8
+
+/blog/gate-api
+  Content-Type: text/html; charset=utf-8
+
+/blog/gate-lite
+  Content-Type: text/html; charset=utf-8
+
+/blog/managed-bedrock-support
+  Content-Type: text/html; charset=utf-8
+
+/blog/minekube-ai-support-loop
+  Content-Type: text/html; charset=utf-8
+
+/blog/minekube-browser-apis-agents
+  Content-Type: text/html; charset=utf-8
+
+/blog/minekube-control-plane
+  Content-Type: text/html; charset=utf-8
+
+/plans
+  Content-Type: text/html; charset=utf-8
+
+/team
+  Content-Type: text/html; charset=utf-8
+
+/*.css
+  Content-Type: text/css; charset=utf-8
+
+/*.js
+  Content-Type: application/javascript
+
+/*.jpeg
+  cache-control: public, max-age=14400, must-revalidate
+
+/vp-icons.css
+  cache-control: public, max-age=14400, must-revalidate
+
 /assets/*
   cache-control: max-age=31536000
   cache-control: immutable

--- a/.web/package.json
+++ b/.web/package.json
@@ -8,6 +8,9 @@
     "check:docs": "node scripts/check-docs.mjs",
     "check:plugin-download": "node scripts/check-plugin-download.mjs",
     "build": "vitepress build docs",
+    "test:worker": "node --test scripts/workers-migration.test.mjs",
+    "deploy:worker": "wrangler deploy",
+    "deploy:worker:canary": "wrangler deploy --config wrangler.canary.jsonc",
     "serve": "vitepress serve docs"
   },
   "devDependencies": {
@@ -16,7 +19,8 @@
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
     "vitepress": "^1.6.4",
-    "vue": "^3.5.35"
+    "vue": "^3.5.35",
+    "wrangler": "4.115.0"
   },
   "postcss": {
     "plugins": {

--- a/.web/scripts/workers-migration.test.mjs
+++ b/.web/scripts/workers-migration.test.mjs
@@ -1,0 +1,420 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import worker from '../worker.mjs';
+import { normalizePagesResponse } from '../worker-response.mjs';
+
+const redirectPaths = [
+  '/*.html',
+  '/discord',
+  '/discord/',
+  '/guide/changelog',
+  '/guide/changelog/',
+  '/guide/changelog.html',
+];
+
+const readConfig = async (name) =>
+  JSON.parse(await readFile(new URL(`../${name}`, import.meta.url), 'utf8'));
+
+const hasHeaderRule = (headers, path, name, value) => {
+  const start = headers.indexOf(`${path}\n`);
+  const end = headers.indexOf('\n\n', start);
+  const rule = headers.slice(start, end === -1 ? undefined : end);
+  return rule.includes(
+    value === undefined
+      ? `  ${name}`
+      : `  ${name}: ${value}`
+  );
+};
+
+test('production and canary Workers preserve the Connect Pages contract', async () => {
+  const production = await readConfig('wrangler.jsonc');
+  const canary = await readConfig('wrangler.canary.jsonc');
+  const headers = await readFile(
+    new URL('../docs/public/_headers', import.meta.url),
+    'utf8'
+  );
+  const redirects = await readFile(
+    new URL('../docs/public/_redirects', import.meta.url),
+    'utf8'
+  );
+  const packageJson = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf8')
+  );
+  const shared = {
+    compatibility_date: '2026-08-07',
+    main: 'worker.mjs',
+    assets: {
+      directory: 'docs/.vitepress/dist',
+      binding: 'ASSETS',
+      run_worker_first: redirectPaths,
+    },
+  };
+
+  assert.equal(packageJson.packageManager, 'yarn@4.17.1');
+  assert.equal(packageJson.devDependencies.wrangler, '4.115.0');
+  assert.equal(
+    packageJson.scripts['test:worker'],
+    'node --test scripts/workers-migration.test.mjs'
+  );
+  assert.equal(packageJson.scripts['deploy:worker'], 'wrangler deploy');
+  assert.equal(
+    packageJson.scripts['deploy:worker:canary'],
+    'wrangler deploy --config wrangler.canary.jsonc'
+  );
+
+  for (const config of [production, canary]) {
+    assert.equal(config.compatibility_date, shared.compatibility_date);
+    assert.equal(config.main, shared.main);
+    assert.deepEqual(config.assets, shared.assets);
+  }
+
+  assert.equal(production.name, 'connect-minekube-worker');
+  assert.equal(production.workers_dev, false);
+  assert.equal(production.preview_urls, false);
+  assert.deepEqual(production.routes, [
+    { pattern: 'connect.minekube.com', custom_domain: true },
+  ]);
+
+  assert.equal(canary.name, 'connect-minekube-worker-canary');
+  assert.equal(canary.workers_dev, false);
+  assert.equal(canary.preview_urls, false);
+  assert.deepEqual(canary.routes, [
+    { pattern: 'connect-docs-canary.minekube.com', custom_domain: true },
+  ]);
+
+  assert.match(
+    headers,
+    /\/\*\n  Access-Control-Allow-Origin: \*\n  X-Content-Type-Options: nosniff\n  Referrer-Policy: strict-origin-when-cross-origin/
+  );
+
+  assert.doesNotMatch(redirects, / 308$/m);
+
+  for (const path of [
+    '/',
+    '/guide/*',
+    '/changelog/*',
+    '/blog/',
+    '/blog/gate-api',
+    '/blog/gate-lite',
+    '/blog/managed-bedrock-support',
+    '/blog/minekube-ai-support-loop',
+    '/blog/minekube-browser-apis-agents',
+    '/blog/minekube-control-plane',
+    '/plans',
+    '/team',
+  ]) {
+    assert.equal(
+      hasHeaderRule(headers, path, 'Content-Type', 'text/html; charset=utf-8'),
+      true,
+      `missing HTML charset header rule for ${path}`
+    );
+  }
+
+  for (const [path, name, value] of [
+    ['/*.css', 'Content-Type', 'text/css; charset=utf-8'],
+    ['/*.js', 'Content-Type', 'application/javascript'],
+    ['/*.jpeg', 'cache-control', 'public, max-age=14400, must-revalidate'],
+    [
+      '/vp-icons.css',
+      'cache-control',
+      'public, max-age=14400, must-revalidate',
+    ],
+  ]) {
+    assert.equal(
+      hasHeaderRule(headers, path, name, value),
+      true,
+      `missing ${name} header rule for ${path}`
+    );
+  }
+});
+
+test('the Worker preserves Pages response headers and redirect metadata', async () => {
+  const html = normalizePagesResponse(
+    new Response('<!doctype html>', {
+      headers: { 'content-type': 'text/html' },
+    })
+  );
+  assert.equal(html.headers.get('access-control-allow-origin'), '*');
+  assert.equal(html.headers.get('content-type'), 'text/html; charset=utf-8');
+  assert.equal(html.headers.get('x-content-type-options'), 'nosniff');
+  assert.equal(
+    html.headers.get('referrer-policy'),
+    'strict-origin-when-cross-origin'
+  );
+
+  const encoded = normalizePagesResponse(
+    new Response('already encoded', {
+      headers: { 'content-type': 'Text/Plain; Charset=UTF-8' },
+    })
+  );
+  assert.equal(
+    encoded.headers.get('content-type'),
+    'Text/Plain; Charset=UTF-8'
+  );
+
+  const missing = normalizePagesResponse(
+    new Response('missing', {
+      status: 404,
+      headers: {
+        'cache-control': 'public, max-age=0, must-revalidate',
+        'content-type': 'text/html',
+      },
+    })
+  );
+  assert.equal(missing.headers.get('cache-control'), 'no-store');
+
+  const redirect = normalizePagesResponse(
+    new Response('redirecting', {
+      status: 301,
+      headers: {
+        location: '/changelog/',
+        'content-type': 'text/plain',
+      },
+    })
+  );
+  assert.equal(redirect.status, 301);
+  assert.equal(redirect.headers.get('location'), '/changelog/');
+  assert.equal(redirect.headers.get('content-type'), 'text/plain; charset=utf-8');
+
+  const assetRedirect = normalizePagesResponse(
+    new Response(null, {
+      status: 302,
+      headers: { location: 'https://discord.com/invite/6vMDqWE' },
+    })
+  );
+  assert.equal(
+    assetRedirect.headers.get('location'),
+    'https://discord.com/invite/6vMDqWE'
+  );
+  assert.equal(
+    assetRedirect.headers.get('content-type'),
+    'text/plain;charset=UTF-8'
+  );
+});
+
+test('the Worker recreates Pages redirects before Static Assets routing', async () => {
+  const assets = {
+    fetch() {
+      throw new Error('redirect requests must not reach the asset binding');
+    },
+  };
+  const redirects = [
+    ['/discord', 302, 'https://discord.com/invite/6vMDqWE'],
+    ['/discord/', 302, 'https://discord.com/invite/6vMDqWE'],
+    ['/guide/changelog', 301, '/changelog/'],
+    ['/guide/changelog/', 301, '/changelog/'],
+    ['/guide/changelog.html', 301, '/changelog/'],
+  ];
+
+  for (const [path, status, destination] of redirects) {
+    const response = await worker.fetch(
+      new Request(`https://connect.minekube.com${path}?source=test`),
+      { ASSETS: assets }
+    );
+    const location = `${destination}?source=test`;
+    const body = `Redirecting to ${location}`;
+
+    assert.equal(response.status, status);
+    assert.equal(response.headers.get('location'), location);
+    assert.equal(
+      response.headers.get('content-type'),
+      'text/plain;charset=UTF-8'
+    );
+    assert.equal(
+      response.headers.get('content-length'),
+      String(new TextEncoder().encode(body).byteLength)
+    );
+    assert.equal(response.headers.get('access-control-allow-origin'), '*');
+    assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
+    assert.equal(
+      response.headers.get('referrer-policy'),
+      'strict-origin-when-cross-origin'
+    );
+    assert.equal(await response.text(), body);
+
+    const head = await worker.fetch(
+      new Request(`https://connect.minekube.com${path}`, { method: 'HEAD' }),
+      { ASSETS: assets }
+    );
+    assert.equal(head.status, status);
+    assert.equal(head.headers.get('location'), destination);
+    assert.equal(head.headers.get('content-length'), null);
+    assert.equal(await head.text(), '');
+  }
+});
+
+test('the Worker recreates Pages canonical HTML redirects', async () => {
+  const assets = {
+    fetch() {
+      throw new Error('canonical redirects must not reach the asset binding');
+    },
+  };
+  const redirects = [
+    ['/index.html', '/'],
+    ['/guide/topologies.html', '/guide/topologies'],
+    ['/guide/connectors/index.html', '/guide/connectors/'],
+    ['/blog/index.html', '/blog/'],
+  ];
+
+  for (const [path, destination] of redirects) {
+    const response = await worker.fetch(
+      new Request(`https://connect.minekube.com${path}?source=test`),
+      { ASSETS: assets }
+    );
+
+    assert.equal(response.status, 308);
+    assert.equal(response.headers.get('location'), `${destination}?source=test`);
+    assert.equal(response.headers.get('content-length'), '0');
+    assert.equal(response.headers.get('content-type'), null);
+    assert.equal(response.headers.get('x-content-type-options'), null);
+    assert.equal(response.headers.get('access-control-allow-origin'), '*');
+    assert.equal(
+      response.headers.get('referrer-policy'),
+      'strict-origin-when-cross-origin'
+    );
+    assert.equal(await response.text(), '');
+
+    const head = await worker.fetch(
+      new Request(`https://connect.minekube.com${path}`, { method: 'HEAD' }),
+      { ASSETS: assets }
+    );
+    assert.equal(head.status, 308);
+    assert.equal(head.headers.get('location'), destination);
+    assert.equal(head.headers.get('content-length'), null);
+    assert.equal(await head.text(), '');
+  }
+});
+
+test('the Worker serves the branded 404 with the Pages cache contract', async () => {
+  const requests = [];
+  const assets = {
+    fetch(request) {
+      const pathname = new URL(request.url).pathname;
+      requests.push(pathname);
+
+      if (pathname === '/404') {
+        return new Response('<!doctype html><h1>Page not found</h1>', {
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        });
+      }
+
+      return new Response('generic asset miss', { status: 404 });
+    },
+  };
+  const response = await worker.fetch(
+    new Request('https://connect.minekube.com/missing-page'),
+    { ASSETS: assets }
+  );
+
+  assert.deepEqual(requests, ['/missing-page', '/404']);
+  assert.equal(response.status, 404);
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+  assert.equal(response.headers.get('content-type'), 'text/html; charset=utf-8');
+  assert.equal(
+    await response.text(),
+    '<!doctype html><h1>Page not found</h1>'
+  );
+});
+
+test('the branded 404 fetch ignores conditional and range request headers', async () => {
+  const brandedBody = '<!doctype html><h1>Page not found</h1>';
+  const requests = [];
+  const assets = {
+    fetch(request) {
+      requests.push(request);
+      if (new URL(request.url).pathname !== '/404') {
+        return new Response('generic asset miss', { status: 404 });
+      }
+
+      if (request.headers.has('range')) {
+        return new Response(brandedBody.slice(0, 12), {
+          status: 206,
+          headers: {
+            'content-length': '12',
+            'content-range': 'bytes 0-11/39',
+          },
+        });
+      }
+
+      if (request.headers.has('if-none-match')) {
+        return new Response(null, { status: 304 });
+      }
+
+      return new Response(brandedBody, {
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    },
+  };
+
+  const response = await worker.fetch(
+    new Request('https://connect.minekube.com/missing-page', {
+      headers: {
+        'if-modified-since': 'Wed, 21 Oct 2015 07:28:00 GMT',
+        'if-none-match': '"cached-404"',
+        range: 'bytes=0-11',
+      },
+    }),
+    { ASSETS: assets }
+  );
+
+  assert.equal(response.status, 404);
+  assert.equal(await response.text(), brandedBody);
+  assert.equal(requests[1].method, 'GET');
+  assert.equal(requests[1].headers.get('if-modified-since'), null);
+  assert.equal(requests[1].headers.get('if-none-match'), null);
+  assert.equal(requests[1].headers.get('range'), null);
+});
+
+test('the branded 404 response uses a fixed-length body for GET and HEAD', async () => {
+  const brandedBody = '<!doctype html><h1>Page not found</h1>';
+  const contentLength = new TextEncoder().encode(brandedBody).byteLength;
+  const fixedLengths = [];
+  const previousFixedLengthStream = globalThis.FixedLengthStream;
+
+  globalThis.FixedLengthStream = class extends TransformStream {
+    constructor(length) {
+      super();
+      fixedLengths.push(length);
+    }
+  };
+
+  try {
+    const assets = {
+      fetch(request) {
+        if (new URL(request.url).pathname !== '/404') {
+          return new Response('generic asset miss', { status: 404 });
+        }
+
+        return new Response(brandedBody, {
+          headers: {
+            'content-length': String(contentLength),
+            'content-type': 'text/html; charset=utf-8',
+          },
+        });
+      },
+    };
+
+    const response = await worker.fetch(
+      new Request('https://connect.minekube.com/missing-page'),
+      { ASSETS: assets }
+    );
+    const head = await worker.fetch(
+      new Request('https://connect.minekube.com/missing-page', {
+        method: 'HEAD',
+      }),
+      { ASSETS: assets }
+    );
+
+    assert.deepEqual(fixedLengths, [contentLength, contentLength]);
+    assert.equal(response.headers.get('content-length'), String(contentLength));
+    assert.equal(head.headers.get('content-length'), String(contentLength));
+    assert.equal(await response.text(), brandedBody);
+  } finally {
+    if (previousFixedLengthStream === undefined) {
+      delete globalThis.FixedLengthStream;
+    } else {
+      globalThis.FixedLengthStream = previousFixedLengthStream;
+    }
+  }
+});

--- a/.web/worker-response.mjs
+++ b/.web/worker-response.mjs
@@ -1,0 +1,42 @@
+const shouldAddUtf8Charset = (contentType) => {
+  if (!contentType || contentType.toLowerCase().includes('charset=')) {
+    return false;
+  }
+
+  const mediaType = contentType.split(';', 1)[0].trim().toLowerCase();
+  return (
+    mediaType.startsWith('text/') ||
+    mediaType === 'application/javascript' ||
+    mediaType === 'application/x-javascript'
+  );
+};
+
+export const normalizePagesResponse = (response) => {
+  const headers = new Headers(response.headers);
+
+  headers.set('access-control-allow-origin', '*');
+  headers.set('x-content-type-options', 'nosniff');
+  headers.set('referrer-policy', 'strict-origin-when-cross-origin');
+
+  if (response.status === 404) {
+    headers.set('cache-control', 'no-store');
+  }
+
+  const contentType = headers.get('content-type');
+  if (
+    !contentType &&
+    response.status >= 300 &&
+    response.status < 400 &&
+    headers.has('location')
+  ) {
+    headers.set('content-type', 'text/plain;charset=UTF-8');
+  } else if (shouldAddUtf8Charset(contentType)) {
+    headers.set('content-type', `${contentType}; charset=utf-8`);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};

--- a/.web/worker.mjs
+++ b/.web/worker.mjs
@@ -1,0 +1,120 @@
+import { normalizePagesResponse } from './worker-response.mjs';
+
+const redirects = new Map([
+  [
+    '/discord',
+    { status: 302, destination: 'https://discord.com/invite/6vMDqWE' },
+  ],
+  [
+    '/discord/',
+    { status: 302, destination: 'https://discord.com/invite/6vMDqWE' },
+  ],
+  ['/guide/changelog', { status: 301, destination: '/changelog/' }],
+  ['/guide/changelog/', { status: 301, destination: '/changelog/' }],
+  ['/guide/changelog.html', { status: 301, destination: '/changelog/' }],
+]);
+
+const createPagesRedirect = (request, redirect, search) => {
+  const location = `${redirect.destination}${search}`;
+  const body = `Redirecting to ${location}`;
+  const headers = new Headers({
+    'access-control-allow-origin': '*',
+    'content-type': 'text/plain;charset=UTF-8',
+    location,
+    'referrer-policy': 'strict-origin-when-cross-origin',
+    'x-content-type-options': 'nosniff',
+  });
+  let responseBody = null;
+
+  if (request.method !== 'HEAD') {
+    const encodedBody = new TextEncoder().encode(body);
+    headers.set('content-length', String(encodedBody.byteLength));
+    responseBody = body;
+
+    if (typeof FixedLengthStream !== 'undefined') {
+      const { readable, writable } = new FixedLengthStream(
+        encodedBody.byteLength
+      );
+      const writer = writable.getWriter();
+      void writer.write(encodedBody);
+      void writer.close();
+      responseBody = readable;
+    }
+  }
+
+  return new Response(responseBody, {
+    status: redirect.status,
+    headers,
+  });
+};
+
+const createPagesCanonicalRedirect = (request, pathname, search) => {
+  const destination = pathname.endsWith('/index.html')
+    ? pathname.slice(0, -'index.html'.length)
+    : pathname.slice(0, -'.html'.length);
+  const headers = new Headers({
+    'access-control-allow-origin': '*',
+    location: `${destination}${search}`,
+    'referrer-policy': 'strict-origin-when-cross-origin',
+  });
+
+  if (request.method !== 'HEAD') {
+    headers.set('content-length', '0');
+  }
+
+  return new Response(null, {
+    status: 308,
+    headers,
+  });
+};
+
+const createFixedLengthBody = (response) => {
+  const body = response.body;
+  const contentLength = response.headers.get('content-length');
+
+  if (
+    body === null ||
+    contentLength === null ||
+    !/^\d+$/.test(contentLength) ||
+    !Number.isSafeInteger(Number(contentLength)) ||
+    typeof FixedLengthStream === 'undefined'
+  ) {
+    return body;
+  }
+
+  const { readable, writable } = new FixedLengthStream(Number(contentLength));
+  void body.pipeTo(writable);
+  return readable;
+};
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const redirect = redirects.get(url.pathname);
+
+    if (redirect) {
+      return createPagesRedirect(request, redirect, url.search);
+    }
+
+    if (url.pathname.endsWith('.html')) {
+      return createPagesCanonicalRedirect(request, url.pathname, url.search);
+    }
+
+    const response = await env.ASSETS.fetch(request);
+    if (response.status !== 404) {
+      return normalizePagesResponse(response);
+    }
+
+    const notFoundRequest = new Request(new URL('/404', request.url), {
+      method: 'GET',
+    });
+    const notFoundPage = await env.ASSETS.fetch(notFoundRequest);
+
+    return normalizePagesResponse(
+      new Response(createFixedLengthBody(notFoundPage), {
+        status: 404,
+        headers: notFoundPage.headers,
+      })
+    );
+  },
+};

--- a/.web/wrangler.canary.jsonc
+++ b/.web/wrangler.canary.jsonc
@@ -1,0 +1,25 @@
+{
+  "name": "connect-minekube-worker-canary",
+  "compatibility_date": "2026-08-07",
+  "main": "worker.mjs",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    {
+      "pattern": "connect-docs-canary.minekube.com",
+      "custom_domain": true
+    }
+  ],
+  "assets": {
+    "directory": "docs/.vitepress/dist",
+    "binding": "ASSETS",
+    "run_worker_first": [
+      "/*.html",
+      "/discord",
+      "/discord/",
+      "/guide/changelog",
+      "/guide/changelog/",
+      "/guide/changelog.html"
+    ]
+  }
+}

--- a/.web/wrangler.jsonc
+++ b/.web/wrangler.jsonc
@@ -1,0 +1,25 @@
+{
+  "name": "connect-minekube-worker",
+  "compatibility_date": "2026-08-07",
+  "main": "worker.mjs",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    {
+      "pattern": "connect.minekube.com",
+      "custom_domain": true
+    }
+  ],
+  "assets": {
+    "directory": "docs/.vitepress/dist",
+    "binding": "ASSETS",
+    "run_worker_first": [
+      "/*.html",
+      "/discord",
+      "/discord/",
+      "/guide/changelog",
+      "/guide/changelog/",
+      "/guide/changelog.html"
+    ]
+  }
+}

--- a/.web/yarn.lock
+++ b/.web/yarn.lock
@@ -274,6 +274,70 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/kv-asset-handler@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@cloudflare/kv-asset-handler@npm:0.5.0"
+  checksum: 10c0/46863066ff1628aa76946db6ecb5088ae64ba15d7bda7e4935bd1ab1dcf080cef9cd0920205c9508721153365ef1305984e3584e7ad2dd1c9454df984f441edb
+  languageName: node
+  linkType: hard
+
+"@cloudflare/unenv-preset@npm:2.16.1":
+  version: 2.16.1
+  resolution: "@cloudflare/unenv-preset@npm:2.16.1"
+  peerDependencies:
+    unenv: 2.0.0-rc.24
+    workerd: ">1.20260305.0 <2.0.0-0"
+  peerDependenciesMeta:
+    workerd:
+      optional: true
+  checksum: 10c0/08c9bd9ef488a14fd5330eb2c0829fc221f97f12295f8263dc8e3a6816ebd1a629e7255a3619b8bb688f1f58deafe28042c4e90ea84c926438c768f235f82ad9
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-darwin-64@npm:1.20260722.1":
+  version: 1.20260722.1
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20260722.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-darwin-arm64@npm:1.20260722.1":
+  version: 1.20260722.1
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20260722.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-linux-64@npm:1.20260722.1":
+  version: 1.20260722.1
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20260722.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-linux-arm64@npm:1.20260722.1":
+  version: 1.20260722.1
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20260722.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-windows-64@npm:1.20260722.1":
+  version: 1.20260722.1
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20260722.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cspotcode/source-map-support@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:0.3.9"
+  checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
 "@docsearch/css@npm:3.8.2":
   version: 3.8.2
   resolution: "@docsearch/css@npm:3.8.2"
@@ -336,6 +400,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:^1.11.1":
+  version: 1.11.3
+  resolution: "@emnapi/runtime@npm:1.11.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/a00f1020fefb9d4145c367f93a9fddb383a00da8ffd7871e20b19659890379b83aeecb9f84d7d0eda5456343f4a09eb05b0acb5153b0d3d889539dedb1ed87c3
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.1, @emnapi/wasi-threads@npm:^1.2.1":
   version: 1.2.1
   resolution: "@emnapi/wasi-threads@npm:1.2.1"
@@ -352,9 +425,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/aix-ppc64@npm:0.28.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-arm64@npm:0.21.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm64@npm:0.28.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -366,9 +453,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm@npm:0.28.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-x64@npm:0.21.5"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-x64@npm:0.28.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -380,9 +481,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-arm64@npm:0.28.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/darwin-x64@npm:0.21.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-x64@npm:0.28.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -394,9 +509,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.28.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/freebsd-x64@npm:0.21.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-x64@npm:0.28.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -408,9 +537,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm64@npm:0.28.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-arm@npm:0.21.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm@npm:0.28.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -422,9 +565,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ia32@npm:0.28.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-loong64@npm:0.21.5"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-loong64@npm:0.28.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -436,9 +593,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-mips64el@npm:0.28.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-ppc64@npm:0.21.5"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ppc64@npm:0.28.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -450,9 +621,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-riscv64@npm:0.28.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-s390x@npm:0.21.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-s390x@npm:0.28.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -464,10 +649,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-x64@npm:0.28.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.28.1"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/netbsd-x64@npm:0.21.5"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-x64@npm:0.28.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.28.1"
+  conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -478,9 +691,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-x64@npm:0.28.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openharmony-arm64@npm:0.28.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/sunos-x64@npm:0.21.5"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/sunos-x64@npm:0.28.1"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -492,6 +726,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-arm64@npm:0.28.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-ia32@npm:0.21.5"
@@ -499,9 +740,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-ia32@npm:0.28.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-x64@npm:0.21.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-x64@npm:0.28.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -519,6 +774,251 @@ __metadata:
   version: 2.0.0
   resolution: "@iconify/types@npm:2.0.0"
   checksum: 10c0/65a3be43500c7ccacf360e136d00e1717f050b7b91da644e94370256ac66f582d59212bdb30d00788aab4fc078262e91c95b805d1808d654b72f6d2072a7e4b2
+  languageName: node
+  linkType: hard
+
+"@img/colour@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@img/colour@npm:1.1.0"
+  checksum: 10c0/2ebea2c0bbaee73b99badcefa04e1e71d83f36e5369337d3121dca841f4569533c4e2faddda6d62dd247f0d5cca143711f9446c59bcce81e427ba433a7a94a17
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-darwin-arm64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-darwin-arm64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-darwin-x64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-darwin-x64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-freebsd-wasm32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-freebsd-wasm32@npm:0.35.2"
+  dependencies:
+    "@img/sharp-wasm32": "npm:0.35.2"
+  conditions: os=freebsd
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-arm64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.3.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-x64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-darwin-x64@npm:1.3.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-arm64@npm:1.3.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-arm@npm:1.3.1"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-ppc64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-ppc64@npm:1.3.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-riscv64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-riscv64@npm:1.3.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-s390x@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-s390x@npm:1.3.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-x64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-x64@npm:1.3.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-arm64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.3.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-x64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.3.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-arm64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-arm64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-arm@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-arm": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-ppc64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-ppc64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-ppc64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-riscv64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-riscv64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-riscv64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-s390x@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-s390x@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-s390x": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-x64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-x64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linuxmusl-arm64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linuxmusl-x64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-wasm32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-wasm32@npm:0.35.2"
+  dependencies:
+    "@emnapi/runtime": "npm:^1.11.1"
+  checksum: 10c0/13219f97cf867cc3a18612588dbb3f0b046ffa2d94a153f77f32cafb3f822210d7816c63ffd0a63e589ee1c11e0b2b3123d601f6b73f007ee1807a2f838b37c2
+  languageName: node
+  linkType: hard
+
+"@img/sharp-webcontainers-wasm32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-webcontainers-wasm32@npm:0.35.2"
+  dependencies:
+    "@img/sharp-wasm32": "npm:0.35.2"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-win32-arm64@npm:0.35.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-ia32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-win32-ia32@npm:0.35.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-win32-x64@npm:0.35.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -556,14 +1056,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.5":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
@@ -574,6 +1074,16 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.0.3"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+  checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
   languageName: node
   linkType: hard
 
@@ -625,6 +1135,33 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
+  languageName: node
+  linkType: hard
+
+"@poppinss/colors@npm:^4.1.5":
+  version: 4.1.6
+  resolution: "@poppinss/colors@npm:4.1.6"
+  dependencies:
+    kleur: "npm:^4.1.5"
+  checksum: 10c0/5c2cec5393e33294465873002f4c570adf36b5405b9f06551485162a6fb422d01de90ac20cb00800be6ab2f0d93da26e67302e95691dff2e0aa339cf93e5bf7f
+  languageName: node
+  linkType: hard
+
+"@poppinss/dumper@npm:^0.6.4":
+  version: 0.6.5
+  resolution: "@poppinss/dumper@npm:0.6.5"
+  dependencies:
+    "@poppinss/colors": "npm:^4.1.5"
+    "@sindresorhus/is": "npm:^7.0.2"
+    supports-color: "npm:^10.0.0"
+  checksum: 10c0/7a0916fe4ce543cac1e61f09218e5c88b903ad0d853301b790686c772b7f5c595a04beccbf13172e0c77dc64b132b27ad438b888816fd7f6128c816290f9dc1f
+  languageName: node
+  linkType: hard
+
+"@poppinss/exception@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "@poppinss/exception@npm:1.2.3"
+  checksum: 10c0/44e48400c9f2d33a4904bee99321b89239774bb9210049f1c55864725fd524ff55bc78a5a94a13d5edea93b84e13023c229c88ebba8c2dc717fb4b2205e42ac7
   languageName: node
   linkType: hard
 
@@ -861,6 +1398,20 @@ __metadata:
   version: 10.0.2
   resolution: "@shikijs/vscode-textmate@npm:10.0.2"
   checksum: 10c0/36b682d691088ec244de292dc8f91b808f95c89466af421cf84cbab92230f03c8348649c14b3251991b10ce632b0c715e416e992dd5f28ff3221dc2693fd9462
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/is@npm:^7.0.2":
+  version: 7.2.0
+  resolution: "@sindresorhus/is@npm:7.2.0"
+  checksum: 10c0/0040c17d7826414363f99f5d56077c200789d51e6dfe5542920bfb29ab3828ec0ebf2845e8bae796bee461debb646b5e4c0a623140131cf3143471e915b50b54
+  languageName: node
+  linkType: hard
+
+"@speed-highlight/core@npm:^1.2.7":
+  version: 1.2.17
+  resolution: "@speed-highlight/core@npm:1.2.17"
+  checksum: 10c0/867b896388e9131dca5e49292ea4c6b025d1a8d3d3bd08504d1a43e49dad208d1199e2708bd592135706504a0048e99ea28c1a33a57320e11e39075fe8c680e6
   languageName: node
   linkType: hard
 
@@ -1589,6 +2140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"blake3-wasm@npm:2.1.5":
+  version: 2.1.5
+  resolution: "blake3-wasm@npm:2.1.5"
+  checksum: 10c0/5dc729d8e3a9d1d7ab016b36cdda264a327ada0239716df48435163e11d2bf6df25d6e421655a1f52649098ae49555268a654729b7d02768f77c571ab37ef814
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^2.0.1":
   version: 2.0.1
   resolution: "brace-expansion@npm:2.0.1"
@@ -1689,8 +2247,16 @@ __metadata:
     three: "npm:^0.184.0"
     vitepress: "npm:^1.6.4"
     vue: "npm:^3.5.35"
+    wrangler: "npm:4.115.0"
   languageName: unknown
   linkType: soft
+
+"cookie@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
+  languageName: node
+  linkType: hard
 
 "copy-anything@npm:^3.0.2":
   version: 3.0.5
@@ -1897,7 +2463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.3":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
@@ -2004,6 +2570,102 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: 10c0/b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
+  languageName: node
+  linkType: hard
+
+"error-stack-parser-es@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "error-stack-parser-es@npm:1.0.5"
+  checksum: 10c0/040665eb87a42fe068c0da501bc258f3d15d3a03963c0723d7a2741e251d400c9776a52d2803afdc5709def99554cdb5a5d99c203c7eaf4885d3fbc217e2e8f7
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:0.28.1":
+  version: 0.28.1
+  resolution: "esbuild@npm:0.28.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.28.1"
+    "@esbuild/android-arm": "npm:0.28.1"
+    "@esbuild/android-arm64": "npm:0.28.1"
+    "@esbuild/android-x64": "npm:0.28.1"
+    "@esbuild/darwin-arm64": "npm:0.28.1"
+    "@esbuild/darwin-x64": "npm:0.28.1"
+    "@esbuild/freebsd-arm64": "npm:0.28.1"
+    "@esbuild/freebsd-x64": "npm:0.28.1"
+    "@esbuild/linux-arm": "npm:0.28.1"
+    "@esbuild/linux-arm64": "npm:0.28.1"
+    "@esbuild/linux-ia32": "npm:0.28.1"
+    "@esbuild/linux-loong64": "npm:0.28.1"
+    "@esbuild/linux-mips64el": "npm:0.28.1"
+    "@esbuild/linux-ppc64": "npm:0.28.1"
+    "@esbuild/linux-riscv64": "npm:0.28.1"
+    "@esbuild/linux-s390x": "npm:0.28.1"
+    "@esbuild/linux-x64": "npm:0.28.1"
+    "@esbuild/netbsd-arm64": "npm:0.28.1"
+    "@esbuild/netbsd-x64": "npm:0.28.1"
+    "@esbuild/openbsd-arm64": "npm:0.28.1"
+    "@esbuild/openbsd-x64": "npm:0.28.1"
+    "@esbuild/openharmony-arm64": "npm:0.28.1"
+    "@esbuild/sunos-x64": "npm:0.28.1"
+    "@esbuild/win32-arm64": "npm:0.28.1"
+    "@esbuild/win32-ia32": "npm:0.28.1"
+    "@esbuild/win32-x64": "npm:0.28.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/29cd456a79ce35ac2c7e05fe871330416b2c395c045d849653f843e51378d6e0d6e774d6dcd01b35f4e83238a29bf8decd04fcd34b3780c589a250b21e5f92bb
   languageName: node
   linkType: hard
 
@@ -2174,6 +2836,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.3, fsevents@npm:~2.3.3":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
@@ -2184,12 +2856,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.3":
+"fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
-  resolution: "fsevents@npm:2.3.3"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
     node-gyp: "npm:latest"
-  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -2197,15 +2868,6 @@ __metadata:
 "fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
-  dependencies:
-    node-gyp: "npm:latest"
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
-  version: 2.3.3
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
@@ -2431,6 +3093,13 @@ __metadata:
   dependencies:
     lodash-es: "npm:4"
   checksum: 10c0/023322fdfa41e98a2b83ee02cd00509f3b5041c542dd4405dc3fee2e8cb0928e24a5e681ea1c3df86c82f5fbfcbe61161bfc9ea16dd9f353d7332b314ce34cf6
+  languageName: node
+  linkType: hard
+
+"kleur@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "kleur@npm:4.1.5"
+  checksum: 10c0/e9de6cb49657b6fa70ba2d1448fd3d691a5c4370d8f7bbf1c2f64c24d461270f2117e1b0afe8cb3114f13bbd8e51de158c2a224953960331904e636a5e4c0f2a
   languageName: node
   linkType: hard
 
@@ -2680,6 +3349,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"miniflare@npm:4.20260722.1":
+  version: 4.20260722.1
+  resolution: "miniflare@npm:4.20260722.1"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:0.8.1"
+    sharp: "npm:0.35.2"
+    undici: "npm:7.28.0"
+    workerd: "npm:1.20260722.1"
+    ws: "npm:8.21.0"
+    youch: "npm:4.1.0-beta.10"
+  bin:
+    miniflare: bootstrap.js
+  checksum: 10c0/04caa4b8a9087868a5287c10f9abe037e785cfd258176e67b9bdd341c408c8b3a8c330c863c0262e310b8da45887636cf03112ee033d8b2e13697cd364d2d0d0
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.1":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
@@ -2893,6 +3578,20 @@ __metadata:
     lru-cache: "npm:^9.1.1 || ^10.0.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/e5dc78a7348d25eec61ab166317e9e9c7b46818aa2c2b9006c507a6ff48c672d011292d9662527213e558f5652ce0afcc788663a061d8b59ab495681840c0c1e
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
+  languageName: node
+  linkType: hard
+
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
   languageName: node
   linkType: hard
 
@@ -3164,6 +3863,102 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.8.4":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
+  languageName: node
+  linkType: hard
+
+"sharp@npm:0.35.2":
+  version: 0.35.2
+  resolution: "sharp@npm:0.35.2"
+  dependencies:
+    "@img/colour": "npm:^1.1.0"
+    "@img/sharp-darwin-arm64": "npm:0.35.2"
+    "@img/sharp-darwin-x64": "npm:0.35.2"
+    "@img/sharp-freebsd-wasm32": "npm:0.35.2"
+    "@img/sharp-libvips-darwin-arm64": "npm:1.3.1"
+    "@img/sharp-libvips-darwin-x64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-arm": "npm:1.3.1"
+    "@img/sharp-libvips-linux-arm64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-ppc64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-riscv64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-s390x": "npm:1.3.1"
+    "@img/sharp-libvips-linux-x64": "npm:1.3.1"
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.3.1"
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.3.1"
+    "@img/sharp-linux-arm": "npm:0.35.2"
+    "@img/sharp-linux-arm64": "npm:0.35.2"
+    "@img/sharp-linux-ppc64": "npm:0.35.2"
+    "@img/sharp-linux-riscv64": "npm:0.35.2"
+    "@img/sharp-linux-s390x": "npm:0.35.2"
+    "@img/sharp-linux-x64": "npm:0.35.2"
+    "@img/sharp-linuxmusl-arm64": "npm:0.35.2"
+    "@img/sharp-linuxmusl-x64": "npm:0.35.2"
+    "@img/sharp-webcontainers-wasm32": "npm:0.35.2"
+    "@img/sharp-win32-arm64": "npm:0.35.2"
+    "@img/sharp-win32-ia32": "npm:0.35.2"
+    "@img/sharp-win32-x64": "npm:0.35.2"
+    detect-libc: "npm:^2.1.2"
+    semver: "npm:^7.8.4"
+  dependenciesMeta:
+    "@img/sharp-darwin-arm64":
+      optional: true
+    "@img/sharp-darwin-x64":
+      optional: true
+    "@img/sharp-freebsd-wasm32":
+      optional: true
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+    "@img/sharp-linux-arm":
+      optional: true
+    "@img/sharp-linux-arm64":
+      optional: true
+    "@img/sharp-linux-ppc64":
+      optional: true
+    "@img/sharp-linux-riscv64":
+      optional: true
+    "@img/sharp-linux-s390x":
+      optional: true
+    "@img/sharp-linux-x64":
+      optional: true
+    "@img/sharp-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-linuxmusl-x64":
+      optional: true
+    "@img/sharp-webcontainers-wasm32":
+      optional: true
+    "@img/sharp-win32-arm64":
+      optional: true
+    "@img/sharp-win32-ia32":
+      optional: true
+    "@img/sharp-win32-x64":
+      optional: true
+  checksum: 10c0/e806bbc993eb51b5ac66a852a3aa1ddb01da8f8495b81d31d05c53aacc571180c2eaf263b9a95df8572d8c00b2525c594d5c9669c9c5b29865e8f99a312d80bc
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -3327,6 +4122,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^10.0.0":
+  version: 10.2.2
+  resolution: "supports-color@npm:10.2.2"
+  checksum: 10c0/fb28dd7e0cdf80afb3f2a41df5e068d60c8b4f97f7140de2eaed5b42e075d82a0e980b20a2c0efd2b6d73cfacb55555285d8cc719fa0472220715aefeaa1da7c
+  languageName: node
+  linkType: hard
+
 "tabbable@npm:^6.2.0":
   version: 6.2.0
   resolution: "tabbable@npm:6.2.0"
@@ -3472,6 +4274,22 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"undici@npm:7.28.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
+  languageName: node
+  linkType: hard
+
+"unenv@npm:2.0.0-rc.24":
+  version: 2.0.0-rc.24
+  resolution: "unenv@npm:2.0.0-rc.24"
+  dependencies:
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/e8556b4287fcf647f23db790eea2782cc79f182370718680e3aba4753d5fb7177abf5d6df489c8f74f7e3ad6cd554b8623cc01caf3e6f2d5548e69178adb1691
   languageName: node
   linkType: hard
 
@@ -3705,6 +4523,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workerd@npm:1.20260722.1":
+  version: 1.20260722.1
+  resolution: "workerd@npm:1.20260722.1"
+  dependencies:
+    "@cloudflare/workerd-darwin-64": "npm:1.20260722.1"
+    "@cloudflare/workerd-darwin-arm64": "npm:1.20260722.1"
+    "@cloudflare/workerd-linux-64": "npm:1.20260722.1"
+    "@cloudflare/workerd-linux-arm64": "npm:1.20260722.1"
+    "@cloudflare/workerd-windows-64": "npm:1.20260722.1"
+  dependenciesMeta:
+    "@cloudflare/workerd-darwin-64":
+      optional: true
+    "@cloudflare/workerd-darwin-arm64":
+      optional: true
+    "@cloudflare/workerd-linux-64":
+      optional: true
+    "@cloudflare/workerd-linux-arm64":
+      optional: true
+    "@cloudflare/workerd-windows-64":
+      optional: true
+  bin:
+    workerd: bin/workerd
+  checksum: 10c0/4c5f05455222d2d31e34064a1d529242f6ed021d01a48e43fbdf6f9572600e354e955b1ecbe53648b12e1bc9add21064db101d73c018756f147c4fbbd796de21
+  languageName: node
+  linkType: hard
+
+"wrangler@npm:4.115.0":
+  version: 4.115.0
+  resolution: "wrangler@npm:4.115.0"
+  dependencies:
+    "@cloudflare/kv-asset-handler": "npm:0.5.0"
+    "@cloudflare/unenv-preset": "npm:2.16.1"
+    blake3-wasm: "npm:2.1.5"
+    esbuild: "npm:0.28.1"
+    fsevents: "npm:2.3.3"
+    miniflare: "npm:4.20260722.1"
+    path-to-regexp: "npm:6.3.0"
+    unenv: "npm:2.0.0-rc.24"
+    workerd: "npm:1.20260722.1"
+  peerDependencies:
+    "@cloudflare/workers-types": ^5.20260722.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@cloudflare/workers-types":
+      optional: true
+  bin:
+    cf-wrangler: bin/cf-wrangler.js
+    wrangler: bin/wrangler.js
+    wrangler2: bin/wrangler.js
+  checksum: 10c0/426146cedd16de2c060985e013cb0134aa5f52a63c8d270361a041cccf7e5dc4a5cbfa23429880a04a0bdbb5a983281407b3115353d9f587190c6f807e3ff188
+  languageName: node
+  linkType: hard
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -3727,6 +4600,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:8.21.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
+  languageName: node
+  linkType: hard
+
 "xml-js@npm:^1.6.11":
   version: 1.6.11
   resolution: "xml-js@npm:1.6.11"
@@ -3742,6 +4630,29 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
+  languageName: node
+  linkType: hard
+
+"youch-core@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "youch-core@npm:0.3.3"
+  dependencies:
+    "@poppinss/exception": "npm:^1.2.2"
+    error-stack-parser-es: "npm:^1.0.5"
+  checksum: 10c0/fe101a037a6cfaaa4e80e3d062ff33d4b087b65e3407e65220b453c9b2a66c87ea348a7da0239b61623d929d8fa0a9e139486eaa690ef5605bb49947a2fa82f6
+  languageName: node
+  linkType: hard
+
+"youch@npm:4.1.0-beta.10":
+  version: 4.1.0-beta.10
+  resolution: "youch@npm:4.1.0-beta.10"
+  dependencies:
+    "@poppinss/colors": "npm:^4.1.5"
+    "@poppinss/dumper": "npm:^0.6.4"
+    "@speed-highlight/core": "npm:^1.2.7"
+    cookie: "npm:^1.0.2"
+    youch-core: "npm:^0.3.3"
+  checksum: 10c0/588d65aa5837a46c8473cf57a9129115383f57aad5899915d37005950decfefc66bec85b8a1262dbefd623a122c279095074655889317311a554f9c2e290a5b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Intent

Migrate the public Connect documentation site from Cloudflare Pages to Cloudflare Workers Static Assets with a canary-first, reversible rollout. Preserve every current route, clean/canonical HTML behavior, redirect, RSS feed, response status/body/content length/query propagation, cache behavior, CORS header, MIME type, charset, nosniff header, referrer policy, and branded 404 behavior without SPA fallback. Keep successful static assets on the native assets path and invoke Worker code only for legacy redirects, canonical .html redirects, and asset misses. The route-free canary at https://connect-minekube-worker-canary.robinbraemer.workers.dev version da56cac8-eb36-4a6b-8d48-601d456d5758 has already passed a 38-page live clean/canonical matrix, legacy redirect/RSS/404/HEAD/range/conditional checks, eight asset-class checks, and final real-Chrome RSS-link clicks. Keep the production custom hostname untouched until validation completes. Keep all private Cloudflare account inventory and unrelated domains out of this repository. Do not merge; validate and prepare a reviewable PR only.

## What Changed

- Add Cloudflare Workers Static Assets configuration, Wrangler deployment scripts, and a route-free canary setup for the documentation site.
- Preserve legacy and canonical HTML redirects, Pages-compatible response headers, and branded 404 handling while retaining native static-asset serving.
- Add migration parity coverage and rollout documentation for the Workers deployment.

## Risk Assessment

✅ Low: The updated canonical `/404` asset fetch resolves the prior branded-404 failure, and the remaining migration changes are bounded and consistent with the stated routing and parity requirements.

## Testing

The dependency-free command underlying the Worker test script completed successfully after the uninstalled Yarn wrapper could not run. Live canary evidence confirms query-preserving redirects, RSS, native static-asset cache behavior and conditional 304, plus a no-store branded 404 without SPA fallback; the rendered screenshot confirms the public 404 surface. No worktree artifacts were created.

- Evidence: Rendered branded 404 on Workers canary (local file: <code>/var/folders/1y/cjgf53nj31n_dxsspqnjfjvc0000gn/T/no-mistakes-evidence/01KYPQM3X20SESTXYCW39K63MC/canary-branded-404.png</code>)
<details>
<summary>Evidence: Canary HTTP contract: redirects, RSS, asset cache/range, and 404</summary>

```text
GET /?verification=workers-migration
HTTP/2 200 
date: Wed, 29 Jul 2026 10:51:29 GMT
content-type: text/html; charset=utf-8
cf-cache-status: HIT
access-control-allow-origin: *
cache-control: public, max-age=0, must-revalidate
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=mHemZqqY51WsfKbzqwKBR%2FQt9dH3FsaQuZ2NCA8kgmUq%2BA0j0guaS88gnNzz0YDWutaFhSVgffqwX9RPvIto3QQN3XDWvZ%2BCSztjq%2BIXfb79BusKo9M4bcyZ1mV5%2FM42%2FrHuYe9KrOLk8e6BSWsSkSW4O6oUo8Yks3QwKa6OLkID%2FDqh6HTUCEBVmnhiOYnxgu6P5MoZ"}]}
server: cloudflare
cf-ray: a22b91934c35d8e7-FRA
alt-svc: h3=":443"; ma=86400


GET /guide/changelog?verification=workers-migration
HTTP/2 301 
date: Wed, 29 Jul 2026 10:51:29 GMT
content-type: text/plain;charset=UTF-8
content-length: 57
location: /changelog/?verification=workers-migration
access-control-allow-origin: *
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=qoVPG245ppiU4N02gFxt7BNwzGZ8Q3xZNvT8mCNa8sV%2FKzgSqGrQ4NknLhO6sFmU%2F1XXbVQzb8BQxeQxdco14AbXFq9gvCvGFdzgmZsvY5S06LIjzRxwRLvvguEApCiCLMPE8vaPzo7kdXZbXgLY%2BrS1sWG1j5wYV%2Bya1k8XBnrl52D%2FMlTNWyAFqs9WJtILDeezKGzx"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a22b91946800d8e7-FRA
alt-svc: h3=":443"; ma=86400

Redirecting to /changelog/?verification=workers-migration
HEAD /guide/topologies.html?verification=workers-migration
HTTP/2 308 
date: Wed, 29 Jul 2026 10:51:29 GMT
location: /guide/topologies?verification=workers-migration
access-control-allow-origin: *
referrer-policy: strict-origin-when-cross-origin
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=hAkpldiTx2wDMTIzPkAh5%2F7WVe31IrHnBTMdPvV1s%2FwPsQIcyLxwSEMe6jbIYkSYhjLkFbZSp%2FV8S65ekk8VV6xJTLXahLoiyjzhmJi8whtbEHKXgodeC5WU57VJiJzD0DX1b4l3qj3%2FdChbvB8jIx8sFmeg05Sd7l%2F1PoYUzEATx6S8dY8ScKH2MgGpyHGbI%2BkKGytw"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a22b91953b4fd8e7-FRA
alt-svc: h3=":443"; ma=86400


GET /changelog.rss?verification=workers-migration (headers and XML prefix)
HTTP/2 200 
date: Wed, 29 Jul 2026 10:51:29 GMT
content-type: application/rss+xml
content-length: 25224
cf-cache-status: HIT
access-control-allow-origin: *
cache-control: public, max-age=0, must-revalidate
etag: "65005aa04130718e6b2c6d9a2837267f"
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=atly4jemB6yFIINR1%2FBogfMJTvbmXMDGfIBUPS7sW5ES3YtaaVQUcdTH53zcwi8efbThET06TsSSzAEWhKHk%2BcspxkAbeUOKuT6SbQuUJ57g3YPnpCIdavj76h4SLMdFtGKsjnnK0D%2FB3S7WdKuBMDz%2FLc8EZgRFOwLPAnAHNojAlRjrHCMC9iX0mNHIC%2BMxx07VrTpI"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a22b91964f77d8e7-FRA
alt-svc: h3=":443"; ma=86400

<?xml version="1.0" encoding="utf-8"?>
<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
    <channel>
        <title>Minekube Changelog</title>
        <link>https://connect.minekube.com/changelog/</link>
        <description>User-visible changes across the Minekube platform. Complete coverage for the Connect plugin, GeyserLite and Craftless since June 4, 2026; selective for Gate and the hosted Connect service.</description>
        <lastBuildDate>Wed, 29 Jul 2026 10:40:59 GMT</lastBuildDate>
        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>

GET /assets/app.CZVMZND7.js (successful static asset)
HTTP/2 200 
date: Wed, 29 Jul 2026 10:51:29 GMT
content-type: application/javascript
content-length: 1352
cf-cache-status: HIT
access-control-allow-origin: *
cache-control: max-age=31536000, immutable
etag: "99f5ecc7c81d55ec0758a25847a563f2"
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=lI63K%2FJf7Ix4RpsCuLJpHhN6xHz%2FRnBeqnwQsIl9vxW3uMTvkJMZ1Rf5uysOGiFBY%2BJ%2BX01Tk8nTlisCOs6jDpIiXBkp8MXaJUyJmXRUVctmKxM%2BVZ6F9F8T4qU0F3C%2F%2FtyDJ%2FuNgXIhehLNfG7cEVhQBtnVT9FkjyscqL%2Fa1g%2F0gqUAZy9Za3a8BOomTzfXBysQMjcU"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a22b91977bf5d8e7-FRA
alt-svc: h3=":443"; ma=86400


GET /assets/app.CZVMZND7.js with Range: bytes=0-127
HTTP/2 200 
date: Wed, 29 Jul 2026 10:51:29 GMT
content-type: application/javascript
content-length: 1352
cf-cache-status: HIT
access-control-allow-origin: *
cache-control: max-age=31536000, immutable
etag: "99f5ecc7c81d55ec0758a25847a563f2"
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=IPt48DNRQpzJbuNWKsTdBCWS1y20NqEdH%2FzYVp7nkmNDd8FQjkScfP5y%2FN0pVWo9jb9sARUu3wL39%2BKXI1Va0PNAv9Y5KV06EN0cGRc7G6%2BtvK4kpKjtF3jF6bByfqTt8hsMzbJRAmJNMF57Tni3iwxDou8220Cz7JQFEU5a%2FAOoun1JFmvHWZlgRJZS0WJzI7vusivJ"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a22b91985f06d8e7-FRA
alt-svc: h3=":443"; ma=86400


GET /does-not-exist?verification=workers-migration (headers and branded-404 prefix)
HTTP/2 404 
date: Wed, 29 Jul 2026 10:51:30 GMT
content-type: text/html; charset=utf-8
cf-cache-status: HIT
access-control-allow-origin: *
cache-control: no-store
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Q0VdQUcP63ELWJ%2F6lCM6PnoTWw654tCK7NayXEnlM%2BvDhmOv4%2FyZ7%2BvtvKb0YawVkAC25NPPpS12RGXfaNkRBAqK96rTRmYyKGMG4fLni6BB7DQdBr4gVso0vOt%2Brb%2F2rGbwlPfyQyX6wXS0E3Rp7osSJjklUF%2BGIC%2B%2FIfZZ%2B6g3W8C5zye7J3H%2FHllWDOCcTmY9F7RT"}]}
server: cloudflare
cf-ray: a22b91995aadd8e7-FRA
alt-svc: h3=":443"; ma=86400

<title>404 | Minekube Connect

HEAD /does-not-exist?verification=workers-migration
HTTP/2 404 
date: Wed, 29 Jul 2026 10:51:30 GMT
content-type: text/html; charset=utf-8
cf-cache-status: HIT
access-control-allow-origin: *
cache-control: no-store
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=wIxjemj7uWlX9rZTmwaR6hzBJdW0FM779LvQ%2FckYV3XNm4UeviAuRnmT%2B%2FqyVHvT0uED5VOQ3OZkNslT%2FRBTIe0hG1nG2CDz%2Fv5e%2Fuka2%2F6guwrkqXeIUVSli5w0StAa%2FrBj4P3Tlj9A7H7J6uQdgEQUOw3mC%2FSMaVlfXFsLwsFFQ0via%2BS7O4KnNx8JBt2do90RrQbQ"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a22b919a7f60d8e7-FRA
alt-svc: h3=":443"; ma=86400

```
</details>
<details>
<summary>Evidence: Canary static-asset conditional request returns 304</summary>

```text
GET /assets/app.CZVMZND7.js with If-None-Match: "99f5ecc7c81d55ec0758a25847a563f2"
HTTP/2 304 
date: Wed, 29 Jul 2026 10:51:52 GMT
content-type: application/javascript
cf-cache-status: HIT
access-control-allow-origin: *
cache-control: max-age=31536000, immutable
etag: "99f5ecc7c81d55ec0758a25847a563f2"
referrer-policy: strict-origin-when-cross-origin
x-content-type-options: nosniff
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=KjuZcKQ5KgpZw9D4c1e9ZkotMWR1bMmKC0yT0vrIWcco7m%2BqnsyXHSK59K43NZNh8Ppx2Ia9g5eUYGf0zHy%2Fvh2GLUL2LmH3IiiFZde0vXmUrlXZOGQJ%2BdiK0RN%2B2vrkHH%2BPbDObYW9FvdlWafHbQB0HzuNUYtfPHevKA6DtRh34Q2VgqJ6K6IAVIVftLRE78XvzocKD"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a22b92252c1ed8e7-FRA
alt-svc: h3=":443"; ma=86400

```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.web/worker.mjs:108` - The required criterion is “Preserve every current route, clean/canonical HTML behavior, redirect, RSS feed, response status/body/content length/query propagation, cache behavior, CORS header, MIME type, charset, nosniff header, referrer policy, and branded 404 behavior without SPA fallback.” At this hunk, `env.ASSETS.fetch(new URL(&#39;/404.html&#39;, ...))` applies Static Assets HTML handling, so the default canonical handling redirects `/404.html` to `/404` (307) instead of returning the file. The Worker then relabels that redirect as a 404, leaving asset misses with an empty/non-branded body (and redirect headers). Fetch the canonical `/404` asset path or explicitly select raw asset handling.

🔧 Fix: Fix branded 404 canonical asset fetch
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn test:worker` (package wrapper attempted; dependencies are not installed in this worktree)</code>
- `node --test scripts/workers-migration.test.mjs`
- `Live canary HTTP matrix for home, legacy redirect, canonical HTML redirect, RSS, JS asset/range, branded 404 GET+HEAD`
- <code>Live canary asset conditional request with `If-None-Match`</code>
- <code>Rendered `https://connect-minekube-worker-canary.robinbraemer.workers.dev/does-not-exist?verification=workers-migration` and captured the branded 404 screenshot</code>
- `Read-only representative production Pages versus canary response probe`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
