### PR TITLE
fix(web): restore legacy Connect download redirect

### DIFF
--- a/.web/package.json
+++ b/.web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vitepress dev docs",
     "check:docs": "node scripts/check-docs.mjs",
+    "check:plugin-download": "node scripts/check-plugin-download.mjs",
     "build": "vitepress build docs",
     "serve": "vitepress serve docs"
   },

--- a/.web/scripts/check-plugin-download.mjs
+++ b/.web/scripts/check-plugin-download.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const url = process.argv[2] ?? 'https://developers.minekube.com/connect/download'
+const minimumJarBytes = 1_000_000
+const allowedContentTypes = new Set([
+  'application/java-archive',
+  'application/octet-stream',
+  'application/zip',
+])
+
+const response = await fetch(url, {
+  headers: {
+    range: 'bytes=0-3',
+  },
+  redirect: 'follow',
+})
+
+if (response.status !== 206) {
+  throw new Error(`expected final HTTP 206 range response, got ${response.status}`)
+}
+
+const contentType = response.headers.get('content-type')?.split(';', 1)[0].trim()
+if (!contentType || !allowedContentTypes.has(contentType)) {
+  throw new Error(`expected jar content type, got ${contentType ?? 'missing'}`)
+}
+
+const contentRange = response.headers.get('content-range')
+const totalBytes = Number.parseInt(contentRange?.match(/^bytes 0-3\/(\d+)$/)?.[1] ?? '', 10)
+if (!Number.isSafeInteger(totalBytes) || totalBytes < minimumJarBytes) {
+  throw new Error(
+    `expected jar size of at least ${minimumJarBytes} bytes, got ${contentRange ?? 'missing content-range'}`,
+  )
+}
+
+const bytes = new Uint8Array(await response.arrayBuffer())
+if (bytes.length !== 4 || bytes[0] !== 0x50 || bytes[1] !== 0x4b) {
+  throw new Error(`expected PK jar magic, got ${Buffer.from(bytes).toString('hex') || 'no bytes'}`)
+}
+
+if (!response.redirected) {
+  throw new Error('expected at least one HTTP redirect before the final jar response')
+}
+
+console.log(
+  JSON.stringify({
+    source: url,
+    finalUrl: response.url,
+    status: response.status,
+    contentType,
+    totalBytes,
+    magic: Buffer.from(bytes).toString('hex'),
+  }),
+)

--- a/.web/workers/developers-redirect/README.md
+++ b/.web/workers/developers-redirect/README.md
@@ -1,7 +1,7 @@
 # Archived developers hostname
 
 `developers.minekube.com` is an archived hostname retained only for compatibility with external links that cannot be updated.
-The `redirect-minekube-developers` Worker preserves its existing catch-all and gives known immovable download links real HTTP redirects.
+The `redirect-minekube-developers` Worker preserves its existing catch-all and gives the known immovable Connect download link a real HTTP redirect.
 
 The Connect Spigot download points at the mutable `latest` GitHub release asset maintained by the Connect Java release workflow.
 The hostname is only a compatibility hop and is not the artifact authority.

--- a/.web/workers/developers-redirect/README.md
+++ b/.web/workers/developers-redirect/README.md
@@ -9,17 +9,17 @@ The hostname is only a compatibility hop and is not the artifact authority.
 Run the local behavior test:
 
 ```sh
-mise exec node@24 -- node --test worker.test.mjs
+mise exec node@24 -- node --test .web/workers/developers-redirect/worker.test.mjs
 ```
 
 After merging a reviewed change, deploy the existing Worker:
 
 ```sh
-mise exec node@24 -- npx --yes wrangler@4.115.0 deploy --config wrangler.jsonc
+mise exec node@24 -- npx --yes wrangler@4.115.0 deploy --config .web/workers/developers-redirect/wrangler.jsonc
 ```
 
-Verify the live download from `.web`:
+Verify the live download:
 
 ```sh
-mise exec node@24 -- node scripts/check-plugin-download.mjs
+mise exec node@24 -- node .web/scripts/check-plugin-download.mjs
 ```

--- a/.web/workers/developers-redirect/README.md
+++ b/.web/workers/developers-redirect/README.md
@@ -1,0 +1,25 @@
+# Archived developers hostname
+
+`developers.minekube.com` is an archived hostname retained only for compatibility with external links that cannot be updated.
+The `redirect-minekube-developers` Worker preserves its existing catch-all and gives known immovable download links real HTTP redirects.
+
+The Connect Spigot download points at the mutable `latest` GitHub release asset maintained by the Connect Java release workflow.
+The hostname is only a compatibility hop and is not the artifact authority.
+
+Run the local behavior test:
+
+```sh
+mise exec node@24 -- node --test worker.test.mjs
+```
+
+After merging a reviewed change, deploy the existing Worker:
+
+```sh
+mise exec node@24 -- npx --yes wrangler@4.115.0 deploy --config wrangler.jsonc
+```
+
+Verify the live download from `.web`:
+
+```sh
+mise exec node@24 -- node scripts/check-plugin-download.mjs
+```

--- a/.web/workers/developers-redirect/worker.mjs
+++ b/.web/workers/developers-redirect/worker.mjs
@@ -1,0 +1,21 @@
+export const connectSpigotDownload =
+  'https://github.com/minekube/connect-java/releases/download/latest/connect-spigot.jar'
+
+const legacyHomepage =
+  '<!DOCTYPE html><meta http-equiv="Refresh" content="0; url=\'https://minekube.com\'" />'
+
+export default {
+  async fetch(request) {
+    const { pathname } = new URL(request.url)
+
+    if (pathname === '/connect/download' || pathname === '/connect/download/') {
+      return Response.redirect(connectSpigotDownload, 302)
+    }
+
+    return new Response(legacyHomepage, {
+      headers: {
+        'content-type': 'text/html;charset=UTF-8',
+      },
+    })
+  },
+}

--- a/.web/workers/developers-redirect/worker.test.mjs
+++ b/.web/workers/developers-redirect/worker.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import worker, { connectSpigotDownload } from './worker.mjs'
+
+test('redirects the legacy Connect download path to the stable Spigot jar', async () => {
+  const response = await worker.fetch(
+    new Request('https://developers.minekube.com/connect/download'),
+  )
+
+  assert.equal(response.status, 302)
+  assert.equal(response.headers.get('location'), connectSpigotDownload)
+})
+
+test('redirects a trailing-slash legacy Connect download path too', async () => {
+  const response = await worker.fetch(
+    new Request('https://developers.minekube.com/connect/download/'),
+  )
+
+  assert.equal(response.status, 302)
+  assert.equal(response.headers.get('location'), connectSpigotDownload)
+})
+
+test('preserves the archived host catch-all for every other path', async () => {
+  const response = await worker.fetch(new Request('https://developers.minekube.com/guide/'))
+
+  assert.equal(response.status, 200)
+  assert.match(response.headers.get('content-type') ?? '', /^text\/html/)
+  assert.equal(
+    await response.text(),
+    '<!DOCTYPE html><meta http-equiv="Refresh" content="0; url=\'https://minekube.com\'" />',
+  )
+})

--- a/.web/workers/developers-redirect/wrangler.jsonc
+++ b/.web/workers/developers-redirect/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "redirect-minekube-developers",
+  "main": "worker.mjs",
+  "compatibility_date": "2026-07-30",
+  "workers_dev": false,
+  "preview_urls": false
+}

--- a/.web/workers/developers-redirect/wrangler.jsonc
+++ b/.web/workers/developers-redirect/wrangler.jsonc
@@ -10,8 +10,5 @@
       "pattern": "developers.minekube.com",
       "custom_domain": true
     }
-  ],
-  "limits": {
-    "cpu_ms": 50
-  }
+  ]
 }

--- a/.web/workers/developers-redirect/wrangler.jsonc
+++ b/.web/workers/developers-redirect/wrangler.jsonc
@@ -3,6 +3,15 @@
   "name": "redirect-minekube-developers",
   "main": "worker.mjs",
   "compatibility_date": "2026-07-30",
-  "workers_dev": false,
-  "preview_urls": false
+  "workers_dev": true,
+  "preview_urls": true,
+  "routes": [
+    {
+      "pattern": "developers.minekube.com",
+      "custom_domain": true
+    }
+  ],
+  "limits": {
+    "cpu_ms": 50
+  }
 }


### PR DESCRIPTION
## Intent

Make https://developers.minekube.com/connect/download return a real HTTP redirect chain to the current downloadable Connect Spigot jar, fixing the exact current 200 HTML meta-refresh failure. Keep developers.minekube.com classified as an archived compatibility-only hostname, preserve its existing catch-all for unrelated paths, and use the active connect-java mutable latest release asset as artifact authority. Add an automated check that follows redirects and validates the final range status, jar content type, size floor, and PK magic. The Worker configuration must explicitly preserve the existing Cloudflare custom-domain target and workers.dev/preview settings. Omit the legacy explicit cpu_ms setting because Cloudflare error 100328 proves the current Free plan rejects CPU-limit declarations; the platform-managed plan limit is the deployable equivalent for this tiny redirect Worker. The captain approved this narrow route and requested autonomous completion, PR/deploy proof, live verification, and no Spigot browser edit.

## What Changed

- Added an archived-host Worker route that redirects `/connect/download` (including the trailing-slash variant) to the mutable `connect-java` latest Spigot JAR asset while preserving the catch-all redirect.
- Added automated redirect validation and Worker tests covering the final range response, JAR content type, size floor, and PK magic.
- Added Wrangler deployment settings and documentation for the custom domain, workers.dev, preview URLs, and platform-managed CPU limits.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves the legacy catch-all and deployment targets, and adds the requested redirect-chain artifact checks without a source-verifiable regression.

## Testing

Focused Worker tests and live end-to-end HTTP verification confirmed the redirect chain, final jar response, artifact checks, and preserved catch-all. No screenshot was produced because this is a non-rendered download endpoint; a redacted HTTP transcript was captured instead.

<details>
<summary>Evidence: Live redirect evidence</summary>

`Live chain: 302 → GitHub latest asset → 302 → 206; application/octet-stream; 62,002,987 bytes; PK magic 504b0304. /guide/ remains 200 HTML meta-refresh.`

```text
Live end-user HTTP verification: https://developers.minekube.com/connect/download

HTTP/2 302
location: https://github.com/minekube/connect-java/releases/download/latest/connect-spigot.jar
HTTP/2 302
location: https://release-assets.githubusercontent.com/... (signed query redacted)
HTTP/2 206
content-type: application/octet-stream
content-range: bytes 0-3/62002987
PK magic: 504b0304

The focused Node checker also reported:
{"source":"https://developers.minekube.com/connect/download","status":206,"contentType":"application/octet-stream","totalBytes":62002987,"magic":"504b0304"}

Archived catch-all verification: GET https://developers.minekube.com/guide/
HTTP/2 200
content-type: text/html;charset=UTF-8
<!DOCTYPE html><meta http-equiv="Refresh" content="0; url='https://minekube.com'" />
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `mise exec node@24 -- node --test .web/workers/developers-redirect/worker.test.mjs`
- `mise exec node@24 -- node .web/scripts/check-plugin-download.mjs`
- `curl --location --range 0-3 --dump-header - --output /dev/null https://developers.minekube.com/connect/download`
- `curl --dump-header - https://developers.minekube.com/guide/`
- `Inspected Wrangler settings for custom domain, workers.dev, preview URLs, and omitted cpu_ms.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
