### PR TITLE
feat(bedrockprincipal): add Bedrock v2 signed-principal protocol corpus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/bedrockprincipal/WIRE_FOLLOWUP.md
+++ b/bedrockprincipal/WIRE_FOLLOWUP.md
@@ -1,0 +1,20 @@
+# Bedrock principal v2 wire follow-on
+
+The repository-local protocol, verifier, replay, metadata, readiness, vector,
+and structural privacy work is intentionally source-only and unreleased.
+
+Consuming proposal messages is a separate follow-on gated on
+`bedrock-option-a-moxy-wire-source` landing and producing its reviewed immutable
+Buf release manifest. Only after that gate may Connect:
+
+1. update the generated `buf.build/minekube/connect` dependency from the
+   released manifest;
+2. expose `SessionProposal` bindings for fields 7–12 and the Watch/libp2p
+   readiness messages;
+3. run `descriptorprivacy.ValidateV2ProposalAdditions` against the actual
+   generated `Session` descriptor; and
+4. add transport round-trip, legacy compatibility, cross-lease, reconnect,
+   malformed-frame, and readiness-consumption tests.
+
+No generated wire type, dependency version, release, endpoint, credential, or
+production behavior is invented by this branch.

--- a/bedrockprincipal/core_vector_test.go
+++ b/bedrockprincipal/core_vector_test.go
@@ -104,6 +104,7 @@ func TestCoreVectorsVerifyAgainstLiteralOutcomes(t *testing.T) {
 			require.Equal(t, vector.ExpectedPrincipal.SubjectKind, principal.SubjectKind())
 			require.Equal(t, vector.ExpectedPrincipal.CanonicalXUID, principal.XUID())
 			require.Equal(t, vector.ExpectedPrincipal.CanonicalUnlinkedUUID, principal.CanonicalUnlinkedUUID())
+			require.Equal(t, vector.ExpectedPrincipal.BedrockDisplayName, principal.BedrockDisplayName())
 			require.Equal(t, GameProfile{UUID: vector.ExpectedPrincipal.EffectiveUUID, Name: vector.ExpectedPrincipal.EffectiveName}, principal.EffectiveGameProfile())
 			require.Equal(t, vector.ExpectedPrincipal.VerificationMethod, principal.Verification().VerificationMethod)
 			require.Equal(t, vector.ExpectedPrincipal.KID, principal.Verification().KID)

--- a/bedrockprincipal/core_vector_test.go
+++ b/bedrockprincipal/core_vector_test.go
@@ -1,0 +1,102 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type coreVector struct {
+	Name                 string                 `json:"name"`
+	CompactJWS           string                 `json:"compact_jws"`
+	TrustedContext       coreTrustedContext     `json:"trusted_context"`
+	VerificationTimeUnix int64                  `json:"verification_time_unix"`
+	ExpectedError        string                 `json:"expected_error"`
+	ExpectedPrincipal    *coreExpectedPrincipal `json:"expected_principal"`
+}
+
+type coreTrustedContext struct {
+	Issuer, TrustDomain, Audience                string
+	EndpointID, OrganizationID, ConnectSessionID string
+	ConnectSessionNonce, SourceProtocol          string
+	SourceProtocolVersion                        int32
+	PolicyRevision                               int64
+}
+
+func (c *coreTrustedContext) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		Issuer                string `json:"issuer"`
+		TrustDomain           string `json:"trust_domain"`
+		Audience              string `json:"audience"`
+		EndpointID            string `json:"endpoint_id"`
+		OrganizationID        string `json:"organization_id"`
+		ConnectSessionID      string `json:"connect_session_id"`
+		ConnectSessionNonce   string `json:"connect_session_nonce"`
+		SourceProtocol        string `json:"source_protocol"`
+		SourceProtocolVersion int32  `json:"source_protocol_version"`
+		PolicyRevision        int64  `json:"policy_revision"`
+	}
+	var value wire
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*c = coreTrustedContext(value)
+	return nil
+}
+
+type coreExpectedPrincipal struct {
+	SubjectKind           SubjectKind     `json:"subject_kind"`
+	CanonicalXUID         CanonicalXUID   `json:"canonical_xuid"`
+	CanonicalUnlinkedUUID uuid.UUID       `json:"canonical_unlinked_uuid"`
+	BedrockDisplayName    string          `json:"bedrock_display_name"`
+	EffectiveUUID         uuid.UUID       `json:"effective_uuid"`
+	EffectiveName         string          `json:"effective_name"`
+	VerificationMethod    string          `json:"verification_method"`
+	KID                   string          `json:"kid"`
+	PolicyRevision        int64           `json:"policy_revision"`
+	LinkedJava            json.RawMessage `json:"linked_java,omitempty"`
+}
+
+func TestCoreVectorsVerifyAgainstLiteralOutcomes(t *testing.T) {
+	raw, err := os.ReadFile("testdata/v2/core-vectors.json")
+	require.NoError(t, err)
+	var vectors []coreVector
+	require.NoError(t, json.Unmarshal(raw, &vectors))
+	for _, vector := range vectors {
+		t.Run(vector.Name, func(t *testing.T) {
+			nonce, err := base64.RawURLEncoding.Strict().DecodeString(vector.TrustedContext.ConnectSessionNonce)
+			require.NoError(t, err)
+			var nonceArray [16]byte
+			copy(nonceArray[:], nonce)
+			contextValue := TrustedProposalContext{
+				Issuer: vector.TrustedContext.Issuer, TrustDomain: vector.TrustedContext.TrustDomain,
+				Audience: vector.TrustedContext.Audience, EndpointID: vector.TrustedContext.EndpointID,
+				OrganizationID: vector.TrustedContext.OrganizationID, ConnectSessionID: vector.TrustedContext.ConnectSessionID,
+				ConnectSessionNonce: nonceArray, SourceProtocol: vector.TrustedContext.SourceProtocol,
+				SourceProtocolVersion: vector.TrustedContext.SourceProtocolVersion, PolicyRevision: vector.TrustedContext.PolicyRevision,
+			}
+			verifier := NewVerifier(VerifierConfiguration{Keys: map[string]ed25519.PublicKey{"connect-v2-test": testPublicKey}, Replay: NewMemoryReplayConsumer(MaxReplayEntries, func() time.Time { return time.Unix(vector.VerificationTimeUnix, 0) }), Now: func() time.Time { return time.Unix(vector.VerificationTimeUnix, 0) }})
+			principal, err := verifier.VerifyAndConsume(context.Background(), mustEnvelope(t, vector.CompactJWS), contextValue)
+			if vector.ExpectedError != "OK" {
+				require.ErrorIs(t, err, PrincipalError(vector.ExpectedError))
+				require.Nil(t, principal)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, vector.ExpectedPrincipal.SubjectKind, principal.SubjectKind())
+			require.Equal(t, vector.ExpectedPrincipal.CanonicalXUID, principal.XUID())
+			require.Equal(t, vector.ExpectedPrincipal.CanonicalUnlinkedUUID, principal.CanonicalUnlinkedUUID())
+			require.Equal(t, GameProfile{UUID: vector.ExpectedPrincipal.EffectiveUUID, Name: vector.ExpectedPrincipal.EffectiveName}, principal.EffectiveGameProfile())
+			require.Equal(t, vector.ExpectedPrincipal.VerificationMethod, principal.Verification().VerificationMethod)
+			require.Equal(t, vector.ExpectedPrincipal.KID, principal.Verification().KID)
+			require.Equal(t, vector.ExpectedPrincipal.PolicyRevision, principal.Bindings().PolicyRevision)
+		})
+	}
+}

--- a/bedrockprincipal/core_vector_test.go
+++ b/bedrockprincipal/core_vector_test.go
@@ -52,16 +52,25 @@ func (c *coreTrustedContext) UnmarshalJSON(data []byte) error {
 }
 
 type coreExpectedPrincipal struct {
-	SubjectKind           SubjectKind     `json:"subject_kind"`
-	CanonicalXUID         CanonicalXUID   `json:"canonical_xuid"`
-	CanonicalUnlinkedUUID uuid.UUID       `json:"canonical_unlinked_uuid"`
-	BedrockDisplayName    string          `json:"bedrock_display_name"`
-	EffectiveUUID         uuid.UUID       `json:"effective_uuid"`
-	EffectiveName         string          `json:"effective_name"`
-	VerificationMethod    string          `json:"verification_method"`
-	KID                   string          `json:"kid"`
-	PolicyRevision        int64           `json:"policy_revision"`
-	LinkedJava            json.RawMessage `json:"linked_java,omitempty"`
+	SubjectKind           SubjectKind             `json:"subject_kind"`
+	CanonicalXUID         CanonicalXUID           `json:"canonical_xuid"`
+	CanonicalUnlinkedUUID uuid.UUID               `json:"canonical_unlinked_uuid"`
+	BedrockDisplayName    string                  `json:"bedrock_display_name"`
+	EffectiveUUID         uuid.UUID               `json:"effective_uuid"`
+	EffectiveName         string                  `json:"effective_name"`
+	VerificationMethod    string                  `json:"verification_method"`
+	KID                   string                  `json:"kid"`
+	PolicyRevision        int64                   `json:"policy_revision"`
+	LinkedJava            *coreExpectedLinkedJava `json:"linked_java,omitempty"`
+}
+
+type coreExpectedLinkedJava struct {
+	UUID           uuid.UUID `json:"uuid"`
+	Name           string    `json:"name"`
+	Provider       string    `json:"provider"`
+	RecordID       string    `json:"record_id"`
+	Revision       int64     `json:"revision"`
+	VerifiedAtUnix int64     `json:"verified_at_unix"`
 }
 
 func TestCoreVectorsVerifyAgainstLiteralOutcomes(t *testing.T) {
@@ -73,6 +82,8 @@ func TestCoreVectorsVerifyAgainstLiteralOutcomes(t *testing.T) {
 		t.Run(vector.Name, func(t *testing.T) {
 			nonce, err := base64.RawURLEncoding.Strict().DecodeString(vector.TrustedContext.ConnectSessionNonce)
 			require.NoError(t, err)
+			require.Len(t, nonce, 16)
+			require.Equal(t, vector.TrustedContext.ConnectSessionNonce, base64.RawURLEncoding.EncodeToString(nonce))
 			var nonceArray [16]byte
 			copy(nonceArray[:], nonce)
 			contextValue := TrustedProposalContext{
@@ -97,6 +108,18 @@ func TestCoreVectorsVerifyAgainstLiteralOutcomes(t *testing.T) {
 			require.Equal(t, vector.ExpectedPrincipal.VerificationMethod, principal.Verification().VerificationMethod)
 			require.Equal(t, vector.ExpectedPrincipal.KID, principal.Verification().KID)
 			require.Equal(t, vector.ExpectedPrincipal.PolicyRevision, principal.Bindings().PolicyRevision)
+			linked, hasLinked := principal.LinkedJava()
+			if vector.ExpectedPrincipal.LinkedJava == nil {
+				require.False(t, hasLinked)
+				return
+			}
+			require.True(t, hasLinked)
+			require.Equal(t, vector.ExpectedPrincipal.LinkedJava.UUID, linked.UUID)
+			require.Equal(t, vector.ExpectedPrincipal.LinkedJava.Name, linked.Name)
+			require.Equal(t, vector.ExpectedPrincipal.LinkedJava.Provider, linked.Provenance.Provider)
+			require.Equal(t, vector.ExpectedPrincipal.LinkedJava.RecordID, linked.Provenance.RecordID)
+			require.Equal(t, vector.ExpectedPrincipal.LinkedJava.Revision, linked.Provenance.Revision)
+			require.Equal(t, time.Unix(vector.ExpectedPrincipal.LinkedJava.VerifiedAtUnix, 0), linked.Provenance.VerifiedAt)
 		})
 	}
 }

--- a/bedrockprincipal/fuzz_test.go
+++ b/bedrockprincipal/fuzz_test.go
@@ -1,0 +1,31 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func FuzzStrictEnvelope(f *testing.F) {
+	raw, err := os.ReadFile("testdata/v2/core-vectors.json")
+	if err != nil {
+		f.Fatal(err)
+	}
+	var vectors []struct {
+		CompactJWS string `json:"compact_jws"`
+	}
+	if err := json.Unmarshal(raw, &vectors); err != nil {
+		f.Fatal(err)
+	}
+	f.Add(vectors[0].CompactJWS)
+	f.Add(".")
+	f.Add("a.b.c")
+	f.Fuzz(func(t *testing.T, compact string) {
+		envelope, err := NewSignedPrincipalEnvelope([]byte(compact))
+		if err != nil {
+			return
+		}
+		_, _ = verifierAt(testNowUnix).VerifyAndConsume(context.Background(), envelope, trustedContext())
+	})
+}

--- a/bedrockprincipal/internal/descriptorprivacy/validate.go
+++ b/bedrockprincipal/internal/descriptorprivacy/validate.go
@@ -8,16 +8,17 @@ import (
 
 type fieldContract struct {
 	name      string
+	label     descriptorpb.FieldDescriptorProto_Label
 	typeValue descriptorpb.FieldDescriptorProto_Type
 }
 
 var v2ProposalAdditions = map[int32]fieldContract{
-	7:  {name: "endpoint_id", typeValue: descriptorpb.FieldDescriptorProto_TYPE_STRING},
-	8:  {name: "organization_id", typeValue: descriptorpb.FieldDescriptorProto_TYPE_STRING},
-	9:  {name: "connect_session_nonce", typeValue: descriptorpb.FieldDescriptorProto_TYPE_BYTES},
-	10: {name: "source_protocol_version", typeValue: descriptorpb.FieldDescriptorProto_TYPE_INT32},
-	11: {name: "policy_revision", typeValue: descriptorpb.FieldDescriptorProto_TYPE_INT64},
-	12: {name: "signed_bedrock_principal_v2", typeValue: descriptorpb.FieldDescriptorProto_TYPE_BYTES},
+	7:  {name: "endpoint_id", label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, typeValue: descriptorpb.FieldDescriptorProto_TYPE_STRING},
+	8:  {name: "organization_id", label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, typeValue: descriptorpb.FieldDescriptorProto_TYPE_STRING},
+	9:  {name: "connect_session_nonce", label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, typeValue: descriptorpb.FieldDescriptorProto_TYPE_BYTES},
+	10: {name: "source_protocol_version", label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, typeValue: descriptorpb.FieldDescriptorProto_TYPE_INT32},
+	11: {name: "policy_revision", label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, typeValue: descriptorpb.FieldDescriptorProto_TYPE_INT64},
+	12: {name: "signed_bedrock_principal_v2", label: descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL, typeValue: descriptorpb.FieldDescriptorProto_TYPE_BYTES},
 }
 
 // ValidateV2ProposalAdditions checks the six frozen additive fields exactly.
@@ -33,7 +34,7 @@ func ValidateV2ProposalAdditions(descriptor *descriptorpb.DescriptorProto) error
 		if !ok {
 			return fmt.Errorf("unexpected v2 proposal field %d %q", number, field.GetName())
 		}
-		if seen[number] || field.GetName() != contract.name || field.GetType() != contract.typeValue {
+		if seen[number] || field.GetName() != contract.name || field.GetLabel() != contract.label || field.GetType() != contract.typeValue {
 			return fmt.Errorf("v2 proposal field %d differs from frozen contract", number)
 		}
 		seen[number] = true

--- a/bedrockprincipal/internal/descriptorprivacy/validate.go
+++ b/bedrockprincipal/internal/descriptorprivacy/validate.go
@@ -1,0 +1,47 @@
+package descriptorprivacy
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+type fieldContract struct {
+	name      string
+	typeValue descriptorpb.FieldDescriptorProto_Type
+}
+
+var v2ProposalAdditions = map[int32]fieldContract{
+	7:  {name: "endpoint_id", typeValue: descriptorpb.FieldDescriptorProto_TYPE_STRING},
+	8:  {name: "organization_id", typeValue: descriptorpb.FieldDescriptorProto_TYPE_STRING},
+	9:  {name: "connect_session_nonce", typeValue: descriptorpb.FieldDescriptorProto_TYPE_BYTES},
+	10: {name: "source_protocol_version", typeValue: descriptorpb.FieldDescriptorProto_TYPE_INT32},
+	11: {name: "policy_revision", typeValue: descriptorpb.FieldDescriptorProto_TYPE_INT64},
+	12: {name: "signed_bedrock_principal_v2", typeValue: descriptorpb.FieldDescriptorProto_TYPE_BYTES},
+}
+
+// ValidateV2ProposalAdditions checks the six frozen additive fields exactly.
+// Existing legacy fields 1-6 are outside this v2 structural boundary.
+func ValidateV2ProposalAdditions(descriptor *descriptorpb.DescriptorProto) error {
+	seen := map[int32]bool{}
+	for _, field := range descriptor.GetField() {
+		number := field.GetNumber()
+		if number < 7 {
+			continue
+		}
+		contract, ok := v2ProposalAdditions[number]
+		if !ok {
+			return fmt.Errorf("unexpected v2 proposal field %d %q", number, field.GetName())
+		}
+		if seen[number] || field.GetName() != contract.name || field.GetType() != contract.typeValue {
+			return fmt.Errorf("v2 proposal field %d differs from frozen contract", number)
+		}
+		seen[number] = true
+	}
+	for number := range v2ProposalAdditions {
+		if !seen[number] {
+			return fmt.Errorf("missing v2 proposal field %d", number)
+		}
+	}
+	return nil
+}

--- a/bedrockprincipal/internal/descriptorprivacy/validate_test.go
+++ b/bedrockprincipal/internal/descriptorprivacy/validate_test.go
@@ -15,6 +15,12 @@ func TestV2ProposalAdditionsExposeOnlyOpaqueEnvelopeAndBindings(t *testing.T) {
 	require.Error(t, ValidateV2ProposalAdditions(descriptor))
 }
 
+func TestV2ProposalAdditionsRejectRepeatedFrozenFields(t *testing.T) {
+	descriptor := approvedDescriptor()
+	descriptor.Field[0].Label = descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum()
+	require.Error(t, ValidateV2ProposalAdditions(descriptor))
+}
+
 func approvedDescriptor() *descriptorpb.DescriptorProto {
 	return &descriptorpb.DescriptorProto{Name: proto.String("Session"), Field: []*descriptorpb.FieldDescriptorProto{
 		{Name: proto.String("endpoint_id"), Number: proto.Int32(7), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum()},

--- a/bedrockprincipal/internal/descriptorprivacy/validate_test.go
+++ b/bedrockprincipal/internal/descriptorprivacy/validate_test.go
@@ -1,0 +1,27 @@
+package descriptorprivacy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func TestV2ProposalAdditionsExposeOnlyOpaqueEnvelopeAndBindings(t *testing.T) {
+	descriptor := approvedDescriptor()
+	require.NoError(t, ValidateV2ProposalAdditions(descriptor))
+	descriptor.Field = append(descriptor.Field, &descriptorpb.FieldDescriptorProto{Name: proto.String("canonical_xuid"), Number: proto.Int32(13), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum()})
+	require.Error(t, ValidateV2ProposalAdditions(descriptor))
+}
+
+func approvedDescriptor() *descriptorpb.DescriptorProto {
+	return &descriptorpb.DescriptorProto{Name: proto.String("Session"), Field: []*descriptorpb.FieldDescriptorProto{
+		{Name: proto.String("endpoint_id"), Number: proto.Int32(7), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum()},
+		{Name: proto.String("organization_id"), Number: proto.Int32(8), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum()},
+		{Name: proto.String("connect_session_nonce"), Number: proto.Int32(9), Type: descriptorpb.FieldDescriptorProto_TYPE_BYTES.Enum()},
+		{Name: proto.String("source_protocol_version"), Number: proto.Int32(10), Type: descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum()},
+		{Name: proto.String("policy_revision"), Number: proto.Int32(11), Type: descriptorpb.FieldDescriptorProto_TYPE_INT64.Enum()},
+		{Name: proto.String("signed_bedrock_principal_v2"), Number: proto.Int32(12), Type: descriptorpb.FieldDescriptorProto_TYPE_BYTES.Enum()},
+	}}
+}

--- a/bedrockprincipal/internal/vectorcmd/main.go
+++ b/bedrockprincipal/internal/vectorcmd/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"go.minekube.com/connect/bedrockprincipal/internal/vectorgen"
+)
+
+func main() {
+	check := flag.String("check", "", "verify that the checked-in vector file regenerates exactly")
+	out := flag.String("out", "", "write regenerated vectors to this explicit path")
+	flag.Parse()
+	if (*check == "") == (*out == "") {
+		log.Fatal("exactly one of -check or -out is required")
+	}
+	path := *check
+	if path == "" {
+		path = *out
+	}
+	checked, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	regenerated, err := vectorgen.Regenerate(checked)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if *check != "" {
+		if !bytes.Equal(checked, regenerated) {
+			log.Fatal("checked-in vectors differ from deterministic regeneration")
+		}
+		fmt.Println("core vectors regenerate exactly")
+		return
+	}
+	if err := os.WriteFile(path, regenerated, 0o644); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/bedrockprincipal/internal/vectorgen/generator.go
+++ b/bedrockprincipal/internal/vectorgen/generator.go
@@ -1,0 +1,139 @@
+package vectorgen
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+const fixedNow = int64(1785492000)
+
+type vector struct {
+	Name                 string          `json:"name"`
+	CompactJWS           string          `json:"compact_jws"`
+	TrustedContext       json.RawMessage `json:"trusted_context"`
+	VerificationTimeUnix int64           `json:"verification_time_unix"`
+	ExpectedError        string          `json:"expected_error"`
+	ExpectedPrincipal    json.RawMessage `json:"expected_principal"`
+}
+
+// Regenerate signs only the predefined payload associated with each reviewed
+// vector name. Trusted context and expected outcomes remain checked-in literals.
+func Regenerate(checked []byte) ([]byte, error) {
+	var vectors []vector
+	if err := json.Unmarshal(checked, &vectors); err != nil {
+		return nil, err
+	}
+	if len(vectors) != len(definitions()) {
+		return nil, fmt.Errorf("expected %d vectors, got %d", len(definitions()), len(vectors))
+	}
+	seen := make(map[string]bool, len(vectors))
+	for i := range vectors {
+		if seen[vectors[i].Name] {
+			return nil, fmt.Errorf("duplicate vector %q", vectors[i].Name)
+		}
+		seen[vectors[i].Name] = true
+		definition, ok := definitions()[vectors[i].Name]
+		if !ok {
+			return nil, fmt.Errorf("unknown vector %q", vectors[i].Name)
+		}
+		vectors[i].CompactJWS = sign(definition.payload, definition.tamperSignature)
+	}
+	for name := range definitions() {
+		if !seen[name] {
+			return nil, fmt.Errorf("missing vector %q", name)
+		}
+	}
+	regenerated, err := json.MarshalIndent(vectors, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(regenerated, '\n'), nil
+}
+
+type definition struct {
+	payload         map[string]any
+	tamperSignature bool
+}
+
+func definitions() map[string]definition {
+	validUnlinked := payload(1)
+	validLinked := payload(2)
+	validLinked["subject_kind"] = "bedrock_linked_java"
+	validLinked["verification_method"] = "minecraft_full_jwks+client_jwt+ecdh_v1"
+	validLinked["linked_java"] = map[string]any{
+		"uuid": "123e4567-e89b-12d3-a456-426614174000",
+		"name": "JavaOne",
+		"provenance": map[string]any{
+			"provider": "moxy_account_link_v1", "record_id": "record-test-1",
+			"revision": 3, "verified_at": fixedNow - 10,
+		},
+	}
+	malformedJTI := payload(3)
+	malformedJTI["jti"] = "AAAAAAAAAAAAAAAAAAAAAB"
+	policy := payload(4)
+	lifetime := payload(5)
+	lifetime["exp"] = fixedNow + 31
+	tampered := payload(6)
+	return map[string]definition{
+		"valid-unlinked":           {payload: validUnlinked},
+		"valid-linked":             {payload: validLinked},
+		"malformed-jti-tail-bits":  {payload: malformedJTI},
+		"policy-revision-mismatch": {payload: policy},
+		"lifetime-thirty-one":      {payload: lifetime},
+		"tampered-signature":       {payload: tampered, tamperSignature: true},
+	}
+}
+
+func payload(jtiByte byte) map[string]any {
+	return map[string]any{
+		"version":                 2,
+		"issuer":                  "minekube-connect-test",
+		"trust_domain":            "urn:minekube:connect:test:corpus-v2",
+		"audience":                "urn:minekube:connect:test:bedrock-principal:v2",
+		"subject_kind":            "bedrock_xuid",
+		"canonical_xuid":          "1",
+		"canonical_unlinked_uuid": "00000000-0000-0000-0000-000000000001",
+		"bedrock_display_name":    "BedrockOne",
+		"endpoint_id":             "endpoint-test",
+		"organization_id":         "organization-test",
+		"connect_session_id":      "session-test",
+		"connect_session_nonce":   "AAAAAAAAAAAAAAAAAAAAAA",
+		"policy_revision":         7,
+		"source_protocol":         "bedrock",
+		"source_protocol_version": 776,
+		"iat":                     fixedNow,
+		"nbf":                     fixedNow,
+		"exp":                     fixedNow + 30,
+		"jti":                     base64.RawURLEncoding.EncodeToString(repeated(jtiByte, 16)),
+		"verification_method":     "minecraft_legacy_chain+client_jwt+ecdh_v1",
+	}
+}
+
+func sign(payload map[string]any, tamper bool) string {
+	header := []byte(`{"alg":"EdDSA","typ":"connect-bedrock-principal+jws;v=2","kid":"connect-v2-test"}`)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	protected := base64.RawURLEncoding.EncodeToString(header)
+	encodedPayload := base64.RawURLEncoding.EncodeToString(body)
+	signingInput := protected + "." + encodedPayload
+	seed := sha256.Sum256([]byte("connect-bedrock-principal-v2-test-only"))
+	privateKey := ed25519.NewKeyFromSeed(seed[:])
+	signature := ed25519.Sign(privateKey, []byte(signingInput))
+	if tamper {
+		signature[0] ^= 1
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func repeated(value byte, count int) []byte {
+	result := make([]byte, count)
+	for i := range result {
+		result[i] = value
+	}
+	return result
+}

--- a/bedrockprincipal/internal/vectorgen/generator_test.go
+++ b/bedrockprincipal/internal/vectorgen/generator_test.go
@@ -1,0 +1,17 @@
+package vectorgen
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckedInCoreVectorsRegenerateExactly(t *testing.T) {
+	path := "../../testdata/v2/core-vectors.json"
+	checked, err := os.ReadFile(path)
+	require.NoError(t, err)
+	regenerated, err := Regenerate(checked)
+	require.NoError(t, err)
+	require.Equal(t, string(checked), string(regenerated))
+}

--- a/bedrockprincipal/internal_principal.go
+++ b/bedrockprincipal/internal_principal.go
@@ -1,0 +1,31 @@
+package bedrockprincipal
+
+import "github.com/google/uuid"
+
+type verifiedBedrockPrincipal struct {
+	kind         SubjectKind
+	xuid         CanonicalXUID
+	unlinkedUUID uuid.UUID
+	linked       VerifiedLinkedJavaIdentity
+	hasLinked    bool
+	displayName  string
+	verification VerificationEvidence
+	bindings     PrincipalBindings
+}
+
+func (*verifiedBedrockPrincipal) verifiedPrincipal()                 {}
+func (p *verifiedBedrockPrincipal) SubjectKind() SubjectKind         { return p.kind }
+func (p *verifiedBedrockPrincipal) XUID() CanonicalXUID              { return p.xuid }
+func (p *verifiedBedrockPrincipal) CanonicalUnlinkedUUID() uuid.UUID { return p.unlinkedUUID }
+func (p *verifiedBedrockPrincipal) LinkedJava() (VerifiedLinkedJavaIdentity, bool) {
+	return p.linked, p.hasLinked
+}
+func (p *verifiedBedrockPrincipal) BedrockDisplayName() string         { return p.displayName }
+func (p *verifiedBedrockPrincipal) Verification() VerificationEvidence { return p.verification }
+func (p *verifiedBedrockPrincipal) Bindings() PrincipalBindings        { return p.bindings }
+func (p *verifiedBedrockPrincipal) EffectiveGameProfile() GameProfile {
+	if p.hasLinked {
+		return GameProfile{UUID: p.linked.UUID, Name: p.linked.Name}
+	}
+	return GameProfile{UUID: p.unlinkedUUID, Name: p.displayName}
+}

--- a/bedrockprincipal/manifest_test.go
+++ b/bedrockprincipal/manifest_test.go
@@ -1,0 +1,49 @@
+package bedrockprincipal_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCandidateManifestPinsExactLocalArtifactsAndNoRelease(t *testing.T) {
+	raw, err := os.ReadFile("testdata/v2/connect-sdk-candidate.json")
+	require.NoError(t, err)
+	var manifest struct {
+		SchemaVersion        int    `json:"schema_version"`
+		ApprovalState        string `json:"approval_state"`
+		Commit               any    `json:"commit"`
+		SourceTree           any    `json:"source_tree"`
+		Tag                  any    `json:"tag"`
+		CorpusTree           any    `json:"corpus_tree"`
+		ArtifactSHA256       any    `json:"artifact_sha256"`
+		GoModule             string `json:"go_module"`
+		CorpusDigestSHA256   string `json:"corpus_digest_sha256"`
+		SchemaSHA256         string `json:"schema_sha256"`
+		MetadataSchemaSHA256 string `json:"metadata_schema_sha256"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &manifest))
+	require.Equal(t, 1, manifest.SchemaVersion)
+	require.Equal(t, "candidate", manifest.ApprovalState)
+	require.Nil(t, manifest.Commit)
+	require.Nil(t, manifest.SourceTree)
+	require.Nil(t, manifest.Tag)
+	require.Nil(t, manifest.CorpusTree)
+	require.Nil(t, manifest.ArtifactSHA256)
+	require.Equal(t, "go.minekube.com/connect", manifest.GoModule)
+	require.Equal(t, fileSHA256(t, "testdata/v2/core-vectors.json"), manifest.CorpusDigestSHA256)
+	require.Equal(t, fileSHA256(t, "schema/v2.schema.json"), manifest.SchemaSHA256)
+	require.Equal(t, fileSHA256(t, "schema/metadata-v2.schema.json"), manifest.MetadataSchemaSHA256)
+}
+
+func fileSHA256(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	digest := sha256.Sum256(raw)
+	return hex.EncodeToString(digest[:])
+}

--- a/bedrockprincipal/metadata.go
+++ b/bedrockprincipal/metadata.go
@@ -1,0 +1,210 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const MetadataPathV2 = "/.well-known/minekube-connect/bedrock-principal-v2.json"
+
+type MetadataConfiguration struct {
+	Origin      string
+	Path        string
+	Issuer      string
+	TrustDomain string
+	Audience    string
+	Client      *http.Client
+	Now         func() time.Time
+}
+
+type MetadataKeyProvider struct {
+	configuration       MetadataConfiguration
+	client              *http.Client
+	now                 func() time.Time
+	mu                  sync.Mutex
+	keys                map[string]metadataKey
+	freshUntil          time.Time
+	nextRefresh         time.Time
+	unknownRefreshAfter time.Time
+	backoff             time.Duration
+	etag                string
+}
+
+type metadataDocumentV2 struct {
+	Issuer             string        `json:"issuer"`
+	TrustDomain        string        `json:"trust_domain"`
+	Audience           string        `json:"audience"`
+	CacheMaxAgeSeconds int64         `json:"cache_max_age_seconds"`
+	Keys               []metadataKey `json:"keys"`
+}
+
+type metadataKey struct {
+	KID   string `json:"kid"`
+	KTY   string `json:"kty"`
+	CRV   string `json:"crv"`
+	ALG   string `json:"alg"`
+	Use   string `json:"use"`
+	X     string `json:"x"`
+	State string `json:"state"`
+	key   ed25519.PublicKey
+}
+
+func NewMetadataKeyProvider(configuration MetadataConfiguration) (*MetadataKeyProvider, error) {
+	origin, err := url.Parse(configuration.Origin)
+	if err != nil || origin.Scheme != "https" || origin.Host == "" || origin.User != nil || origin.RawQuery != "" || origin.Fragment != "" || origin.Path != "" {
+		return nil, fmt.Errorf("invalid metadata origin")
+	}
+	if configuration.Path != MetadataPathV2 || configuration.Issuer == "" || configuration.TrustDomain == "" || configuration.Audience == "" {
+		return nil, fmt.Errorf("invalid metadata trust configuration")
+	}
+	if configuration.TrustDomain == "urn:minekube:connect:production" && configuration.Origin != "https://connect.minekube.com" {
+		return nil, fmt.Errorf("production metadata origin is pinned")
+	}
+	baseClient := configuration.Client
+	if baseClient == nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = (&net.Dialer{Timeout: 2 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+		baseClient = &http.Client{Transport: transport}
+	}
+	clientCopy := *baseClient
+	clientCopy.Timeout = 5 * time.Second
+	clientCopy.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	now := configuration.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &MetadataKeyProvider{configuration: configuration, client: &clientCopy, now: now, keys: map[string]metadataKey{}}, nil
+}
+
+func (p *MetadataKeyProvider) Eligible(ctx context.Context, trustDomain, kid string) (ed25519.PublicKey, error) {
+	if trustDomain != p.configuration.TrustDomain || kid == "" {
+		return nil, Trust
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := p.now()
+	if !now.Before(p.freshUntil) {
+		if now.Before(p.nextRefresh) {
+			return nil, MetadataUnavailable
+		}
+		if err := p.refresh(ctx, now); err != nil {
+			if p.backoff == 0 {
+				p.backoff = time.Second
+			} else {
+				p.backoff *= 2
+			}
+			if p.backoff > 30*time.Second {
+				p.backoff = 30 * time.Second
+			}
+			p.nextRefresh = now.Add(p.backoff)
+			return nil, MetadataUnavailable
+		}
+		p.backoff = 0
+		p.nextRefresh = time.Time{}
+	}
+	key, ok := p.keys[kid]
+	if !ok {
+		if now.Before(p.unknownRefreshAfter) {
+			return nil, Trust
+		}
+		p.unknownRefreshAfter = now.Add(5 * time.Second)
+		if err := p.refresh(ctx, now); err != nil {
+			return nil, MetadataUnavailable
+		}
+		key, ok = p.keys[kid]
+		if !ok {
+			return nil, Trust
+		}
+	}
+	switch key.State {
+	case "current", "next", "previous":
+		return append(ed25519.PublicKey(nil), key.key...), nil
+	case "revoked":
+		return nil, KeyRevoked
+	default:
+		return nil, Trust
+	}
+}
+
+func (p *MetadataKeyProvider) refresh(ctx context.Context, now time.Time) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, p.configuration.Origin+p.configuration.Path, nil)
+	if err != nil {
+		return err
+	}
+	if p.etag != "" {
+		request.Header.Set("If-None-Match", p.etag)
+	}
+	response, err := p.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotModified {
+		return fmt.Errorf("metadata 304 cannot extend expired cache")
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("metadata status %d", response.StatusCode)
+	}
+	contentType := response.Header.Get("Content-Type")
+	if contentType != "application/json" && contentType != "application/json; charset=utf-8" {
+		return fmt.Errorf("metadata content type")
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, 65537))
+	if err != nil || len(raw) > 65536 {
+		return fmt.Errorf("metadata size")
+	}
+	if err := rejectDuplicateMembers(raw, 4); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	var document metadataDocumentV2
+	if err := decoder.Decode(&document); err != nil {
+		return err
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return err
+	}
+	if document.Issuer != p.configuration.Issuer || document.TrustDomain != p.configuration.TrustDomain || document.Audience != p.configuration.Audience || document.CacheMaxAgeSeconds < 1 || document.CacheMaxAgeSeconds > 300 || len(document.Keys) < 1 || len(document.Keys) > 16 {
+		return fmt.Errorf("metadata trust or bounds")
+	}
+	keys := make(map[string]metadataKey, len(document.Keys))
+	for _, value := range document.Keys {
+		if _, duplicate := keys[value.KID]; duplicate {
+			return fmt.Errorf("duplicate kid")
+		}
+		if value.KID == "" || len(value.KID) > 128 || value.KTY != "OKP" || value.CRV != "Ed25519" || value.ALG != "EdDSA" || value.Use != "sig" {
+			return fmt.Errorf("invalid key metadata")
+		}
+		if value.State != "current" && value.State != "next" && value.State != "previous" && value.State != "revoked" && value.State != "disabled" {
+			return fmt.Errorf("invalid key state")
+		}
+		decoded, err := decodeCanonical(value.X, ed25519.PublicKeySize)
+		if err != nil || len(decoded) != ed25519.PublicKeySize {
+			return fmt.Errorf("invalid public key")
+		}
+		value.key = append(ed25519.PublicKey(nil), decoded...)
+		keys[value.KID] = value
+	}
+	p.keys = keys
+	p.freshUntil = now.Add(time.Duration(document.CacheMaxAgeSeconds) * time.Second)
+	p.etag = response.Header.Get("ETag")
+	return nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return fmt.Errorf("trailing json")
+	}
+	return nil
+}

--- a/bedrockprincipal/metadata.go
+++ b/bedrockprincipal/metadata.go
@@ -71,8 +71,12 @@ func NewMetadataKeyProvider(configuration MetadataConfiguration) (*MetadataKeyPr
 	}
 	baseClient := configuration.Client
 	if baseClient == nil {
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.DialContext = (&net.Dialer{Timeout: 2 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+		transport := http.DefaultTransport
+		if defaultTransport, ok := transport.(*http.Transport); ok {
+			clonedTransport := defaultTransport.Clone()
+			clonedTransport.DialContext = (&net.Dialer{Timeout: 2 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+			transport = clonedTransport
+		}
 		baseClient = &http.Client{Transport: transport}
 	}
 	clientCopy := *baseClient

--- a/bedrockprincipal/metadata_test.go
+++ b/bedrockprincipal/metadata_test.go
@@ -34,6 +34,26 @@ func TestMetadataKeyLifecycle(t *testing.T) {
 	}
 }
 
+func TestMetadataProviderHandlesCustomDefaultTransport(t *testing.T) {
+	defaultTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = defaultTransport })
+	http.DefaultTransport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("test transport")
+	})
+
+	var provider *MetadataKeyProvider
+	var err error
+	require.NotPanics(t, func() {
+		provider, err = NewMetadataKeyProvider(MetadataConfiguration{
+			Origin: "https://example.test", Path: MetadataPathV2,
+			Issuer: "minekube-connect-test", TrustDomain: "urn:minekube:connect:test:corpus-v2",
+			Audience: "urn:minekube:connect:test:bedrock-principal:v2",
+		})
+	})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+}
+
 func TestMetadataRejectsWrongContentTypeDuplicateKIDAndOversize(t *testing.T) {
 	duplicate := strings.Replace(metadataDocument("current"), `]}`, `,{"kid":"connect-v2-test","kty":"OKP","crv":"Ed25519","alg":"EdDSA","use":"sig","x":"`+base64.RawURLEncoding.EncodeToString(testPublicKey)+`","state":"next"}]}`, 1)
 	duplicateMember := strings.Replace(metadataDocument("current"), `{"issuer":"minekube-connect-test",`, `{"issuer":"minekube-connect-test","issuer":"minekube-connect-test",`, 1)
@@ -154,4 +174,10 @@ func metadataServer(t *testing.T, body, contentType string) *httptest.Server {
 
 func metadataDocument(state string) string {
 	return fmt.Sprintf(`{"issuer":"minekube-connect-test","trust_domain":"urn:minekube:connect:test:corpus-v2","audience":"urn:minekube:connect:test:bedrock-principal:v2","cache_max_age_seconds":1,"keys":[{"kid":"connect-v2-test","kty":"OKP","crv":"Ed25519","alg":"EdDSA","use":"sig","x":"%s","state":"%s"}]}`, base64.RawURLEncoding.EncodeToString(testPublicKey), state)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
 }

--- a/bedrockprincipal/metadata_test.go
+++ b/bedrockprincipal/metadata_test.go
@@ -1,0 +1,157 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataKeyLifecycle(t *testing.T) {
+	states := []struct {
+		state string
+		want  PrincipalError
+	}{{"current", ""}, {"next", ""}, {"previous", ""}, {"revoked", KeyRevoked}, {"disabled", Trust}}
+	for _, tc := range states {
+		t.Run(tc.state, func(t *testing.T) {
+			server := metadataServer(t, metadataDocument(tc.state), "application/json")
+			provider := newTestMetadataProvider(t, server)
+			key, err := provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "connect-v2-test")
+			if tc.want == "" {
+				require.NoError(t, err)
+				require.Equal(t, testPublicKey, key)
+			} else {
+				require.ErrorIs(t, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestMetadataRejectsWrongContentTypeDuplicateKIDAndOversize(t *testing.T) {
+	duplicate := strings.Replace(metadataDocument("current"), `]}`, `,{"kid":"connect-v2-test","kty":"OKP","crv":"Ed25519","alg":"EdDSA","use":"sig","x":"`+base64.RawURLEncoding.EncodeToString(testPublicKey)+`","state":"next"}]}`, 1)
+	duplicateMember := strings.Replace(metadataDocument("current"), `{"issuer":"minekube-connect-test",`, `{"issuer":"minekube-connect-test","issuer":"minekube-connect-test",`, 1)
+	cases := []struct{ name, body, contentType string }{
+		{"wrong-content-type", metadataDocument("current"), "text/plain"},
+		{"duplicate-kid", duplicate, "application/json"},
+		{"duplicate-member", duplicateMember, "application/json"},
+		{"oversize", strings.Repeat(" ", 65537), "application/json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := metadataServer(t, tc.body, tc.contentType)
+			_, err := newTestMetadataProvider(t, server).Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "connect-v2-test")
+			require.ErrorIs(t, err, MetadataUnavailable)
+		})
+	}
+}
+
+func TestMetadataUsesFreshCacheButNotExpiredCacheDuringOutage(t *testing.T) {
+	var requests atomic.Int32
+	failing := atomic.Bool{}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		if failing.Load() {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, metadataDocument("current"))
+	}))
+	t.Cleanup(server.Close)
+	now := time.Unix(testNowUnix, 0)
+	provider, err := NewMetadataKeyProvider(MetadataConfiguration{
+		Origin: server.URL, Path: "/.well-known/minekube-connect/bedrock-principal-v2.json",
+		Issuer: "minekube-connect-test", TrustDomain: "urn:minekube:connect:test:corpus-v2",
+		Audience: "urn:minekube:connect:test:bedrock-principal:v2", Client: server.Client(), Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	_, err = provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "connect-v2-test")
+	require.NoError(t, err)
+	failing.Store(true)
+	_, err = provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "connect-v2-test")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), requests.Load())
+	now = now.Add(2 * time.Second)
+	_, err = provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "connect-v2-test")
+	require.ErrorIs(t, err, MetadataUnavailable)
+}
+
+func TestMetadataUnknownKIDTriggersOneCoalescedRefreshWindow(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		request := requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		kid := "old"
+		if request > 1 {
+			kid = "new"
+		}
+		fmt.Fprint(w, strings.Replace(metadataDocument("current"), "connect-v2-test", kid, 1))
+	}))
+	t.Cleanup(server.Close)
+	provider := newTestMetadataProvider(t, server)
+	_, err := provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "old")
+	require.NoError(t, err)
+	_, err = provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "new")
+	require.NoError(t, err)
+	require.Equal(t, int32(2), requests.Load())
+	_, err = provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "missing")
+	require.ErrorIs(t, err, Trust)
+	require.Equal(t, int32(2), requests.Load())
+}
+
+func TestMetadata304CannotExtendPastOriginalCacheCeiling(t *testing.T) {
+	var sawConditional atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("If-None-Match") == `"fixture"` {
+			sawConditional.Store(true)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", `"fixture"`)
+		fmt.Fprint(w, metadataDocument("current"))
+	}))
+	t.Cleanup(server.Close)
+	now := time.Unix(testNowUnix, 0)
+	provider, err := NewMetadataKeyProvider(MetadataConfiguration{Origin: server.URL, Path: MetadataPathV2, Issuer: "minekube-connect-test", TrustDomain: "urn:minekube:connect:test:corpus-v2", Audience: "urn:minekube:connect:test:bedrock-principal:v2", Client: server.Client(), Now: func() time.Time { return now }})
+	require.NoError(t, err)
+	_, err = provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "connect-v2-test")
+	require.NoError(t, err)
+	now = now.Add(2 * time.Second)
+	_, err = provider.Eligible(context.Background(), "urn:minekube:connect:test:corpus-v2", "connect-v2-test")
+	require.ErrorIs(t, err, MetadataUnavailable)
+	require.True(t, sawConditional.Load())
+}
+
+func newTestMetadataProvider(t *testing.T, server *httptest.Server) *MetadataKeyProvider {
+	t.Helper()
+	provider, err := NewMetadataKeyProvider(MetadataConfiguration{
+		Origin: server.URL, Path: "/.well-known/minekube-connect/bedrock-principal-v2.json",
+		Issuer: "minekube-connect-test", TrustDomain: "urn:minekube:connect:test:corpus-v2",
+		Audience: "urn:minekube:connect:test:bedrock-principal:v2", Client: server.Client(),
+		Now: func() time.Time { return time.Unix(testNowUnix, 0) },
+	})
+	require.NoError(t, err)
+	return provider
+}
+
+func metadataServer(t *testing.T, body, contentType string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func metadataDocument(state string) string {
+	return fmt.Sprintf(`{"issuer":"minekube-connect-test","trust_domain":"urn:minekube:connect:test:corpus-v2","audience":"urn:minekube:connect:test:bedrock-principal:v2","cache_max_age_seconds":1,"keys":[{"kid":"connect-v2-test","kty":"OKP","crv":"Ed25519","alg":"EdDSA","use":"sig","x":"%s","state":"%s"}]}`, base64.RawURLEncoding.EncodeToString(testPublicKey), state)
+}

--- a/bedrockprincipal/observability.go
+++ b/bedrockprincipal/observability.go
@@ -1,0 +1,14 @@
+package bedrockprincipal
+
+// VerificationEvent is the complete typed observability surface for principal
+// verification. It deliberately cannot carry an envelope or identity value.
+type VerificationEvent struct {
+	Error               PrincipalError `json:"error"`
+	Correlation         [16]byte       `json:"correlation"`
+	KID                 string         `json:"kid"`
+	Ready               bool           `json:"ready"`
+	Linked              bool           `json:"linked"`
+	ReplaySize          uint32         `json:"replay_size"`
+	ActiveCount         uint32         `json:"active_count"`
+	ProfileApplications uint32         `json:"profile_applications"`
+}

--- a/bedrockprincipal/observability_test.go
+++ b/bedrockprincipal/observability_test.go
@@ -1,0 +1,30 @@
+package bedrockprincipal
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerificationEventSchemaAdmitsOnlyNonSecretFields(t *testing.T) {
+	typeInfo := reflect.TypeOf(VerificationEvent{})
+	want := []string{"Error", "Correlation", "KID", "Ready", "Linked", "ReplaySize", "ActiveCount", "ProfileApplications"}
+	var got []string
+	for i := 0; i < typeInfo.NumField(); i++ {
+		got = append(got, typeInfo.Field(i).Name)
+	}
+	require.Equal(t, want, got)
+}
+
+func TestVerificationEventNeverSerializesPrincipalMaterial(t *testing.T) {
+	event := VerificationEvent{Error: LinkInvalid, Correlation: [16]byte{1}, KID: "public-test-kid", Ready: false, Linked: true, ReplaySize: 2, ActiveCount: 3, ProfileApplications: 0}
+	raw, err := json.Marshal(event)
+	require.NoError(t, err)
+	serialized := string(raw)
+	for _, forbidden := range []string{"xuid-sentinel", "display-name-sentinel", "java-uuid-sentinel", "record-sentinel", "jti-sentinel", "nonce-sentinel", "envelope-sentinel"} {
+		require.False(t, strings.Contains(serialized, forbidden))
+	}
+}

--- a/bedrockprincipal/principal.go
+++ b/bedrockprincipal/principal.go
@@ -1,0 +1,19 @@
+package bedrockprincipal
+
+import "github.com/google/uuid"
+
+type VerifiedPrincipal interface {
+	SubjectKind() SubjectKind
+	EffectiveGameProfile() GameProfile
+	verifiedPrincipal()
+}
+
+type VerifiedBedrockPrincipal interface {
+	VerifiedPrincipal
+	XUID() CanonicalXUID
+	CanonicalUnlinkedUUID() uuid.UUID
+	LinkedJava() (VerifiedLinkedJavaIdentity, bool)
+	BedrockDisplayName() string
+	Verification() VerificationEvidence
+	Bindings() PrincipalBindings
+}

--- a/bedrockprincipal/readiness.go
+++ b/bedrockprincipal/readiness.go
@@ -1,0 +1,62 @@
+package bedrockprincipal
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"hash"
+)
+
+type ReadinessState struct {
+	Mode                    string
+	MetadataFresh           bool
+	ReplayAvailable         bool
+	ReplayCapacityAvailable bool
+	SelfCheckPassed         bool
+	EligibleKeyCount        int
+}
+
+func (s ReadinessState) Ready() bool {
+	return s.Mode == "require" && s.MetadataFresh && s.ReplayAvailable &&
+		s.ReplayCapacityAvailable && s.SelfCheckPassed && s.EligibleKeyCount > 0
+}
+
+func (s ReadinessState) Err() error {
+	if s.Ready() {
+		return nil
+	}
+	return Readiness
+}
+
+type ReadinessRevisionInput struct {
+	Issuer                    string
+	TrustDomain               string
+	Audience                  string
+	SDKBuildIdentity          string
+	Capability                string
+	Mode                      string
+	EligibleKeySetDigest      [32]byte
+	ReplayConfigurationDigest [32]byte
+	ProfileApplierIdentity    string
+	SelfCheckCorpusDigest     [32]byte
+}
+
+func (i ReadinessRevisionInput) Revision() [32]byte {
+	digest := sha256.New()
+	for _, value := range []string{i.Issuer, i.TrustDomain, i.Audience, i.SDKBuildIdentity, i.Capability, i.Mode} {
+		writeLengthPrefixed(digest, []byte(value))
+	}
+	writeLengthPrefixed(digest, i.EligibleKeySetDigest[:])
+	writeLengthPrefixed(digest, i.ReplayConfigurationDigest[:])
+	writeLengthPrefixed(digest, []byte(i.ProfileApplierIdentity))
+	writeLengthPrefixed(digest, i.SelfCheckCorpusDigest[:])
+	var result [32]byte
+	copy(result[:], digest.Sum(nil))
+	return result
+}
+
+func writeLengthPrefixed(digest hash.Hash, value []byte) {
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], uint32(len(value)))
+	_, _ = digest.Write(length[:])
+	_, _ = digest.Write(value)
+}

--- a/bedrockprincipal/readiness_test.go
+++ b/bedrockprincipal/readiness_test.go
@@ -1,0 +1,36 @@
+package bedrockprincipal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadinessFailsClosedUnlessRequireAndEveryLocalCheckPasses(t *testing.T) {
+	ready := ReadinessState{Mode: "require", MetadataFresh: true, ReplayAvailable: true, ReplayCapacityAvailable: true, SelfCheckPassed: true, EligibleKeyCount: 1}
+	require.True(t, ready.Ready())
+	cases := map[string]func(*ReadinessState){
+		"warn":               func(s *ReadinessState) { s.Mode = "warn" },
+		"stale-metadata":     func(s *ReadinessState) { s.MetadataFresh = false },
+		"replay-unavailable": func(s *ReadinessState) { s.ReplayAvailable = false },
+		"replay-capacity":    func(s *ReadinessState) { s.ReplayCapacityAvailable = false },
+		"self-check":         func(s *ReadinessState) { s.SelfCheckPassed = false },
+		"no-eligible-key":    func(s *ReadinessState) { s.EligibleKeyCount = 0 },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			state := ready
+			mutate(&state)
+			require.False(t, state.Ready())
+			require.ErrorIs(t, state.Err(), Readiness)
+		})
+	}
+}
+
+func TestReadinessRevisionIsStableAndInputBound(t *testing.T) {
+	input := ReadinessRevisionInput{Issuer: "issuer", TrustDomain: "domain", Audience: "audience", SDKBuildIdentity: "sdk", Capability: Capability, Mode: "require", EligibleKeySetDigest: [32]byte{1}, ReplayConfigurationDigest: [32]byte{2}, ProfileApplierIdentity: "host", SelfCheckCorpusDigest: [32]byte{3}}
+	first := input.Revision()
+	require.Equal(t, first, input.Revision())
+	input.Mode = "warn"
+	require.NotEqual(t, first, input.Revision())
+}

--- a/bedrockprincipal/replay.go
+++ b/bedrockprincipal/replay.go
@@ -1,0 +1,66 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type ReplayEntry struct {
+	TrustDomain  string
+	Issuer       string
+	JTI          string
+	KID          string
+	EndpointID   string
+	SessionID    string
+	SessionNonce [16]byte
+	ExpiresAt    time.Time
+}
+
+type MemoryReplayConsumer struct {
+	maxEntries int
+	now        func() time.Time
+	mu         sync.Mutex
+	entries    map[string]ReplayEntry
+}
+
+func NewMemoryReplayConsumer(maxEntries int, now func() time.Time) *MemoryReplayConsumer {
+	if maxEntries <= 0 || maxEntries > MaxReplayEntries {
+		maxEntries = MaxReplayEntries
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &MemoryReplayConsumer{maxEntries: maxEntries, now: now, entries: make(map[string]ReplayEntry, maxEntries)}
+}
+
+func (c *MemoryReplayConsumer) Consume(_ context.Context, entry ReplayEntry) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	key := entry.TrustDomain + "\x00" + entry.Issuer + "\x00" + entry.JTI
+	if existing, exists := c.entries[key]; exists {
+		if !now.After(existing.ExpiresAt) {
+			return Replay
+		}
+		delete(c.entries, key)
+	}
+	if len(c.entries) >= c.maxEntries {
+		removed := 0
+		for existingKey, existing := range c.entries {
+			if now.After(existing.ExpiresAt) {
+				delete(c.entries, existingKey)
+				removed++
+				if removed == 64 {
+					break
+				}
+			}
+		}
+	}
+	if len(c.entries) >= c.maxEntries {
+		return Capacity
+	}
+	c.entries[key] = entry
+	return nil
+}

--- a/bedrockprincipal/replay_test.go
+++ b/bedrockprincipal/replay_test.go
@@ -1,0 +1,92 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaySameEnvelopeIsOKThenReplay(t *testing.T) {
+	cache := replayCache()
+	entry := replayEntry(1)
+	require.NoError(t, cache.Consume(context.Background(), entry))
+	require.ErrorIs(t, cache.Consume(context.Background(), entry), Replay)
+}
+
+func TestVerifierConsumesSameEnvelopeAsOKThenReplay(t *testing.T) {
+	verifier := verifierAt(testNowUnix)
+	envelope := mustEnvelope(t, signPayload(t, validPayload()))
+	_, err := verifier.VerifyAndConsume(context.Background(), envelope, trustedContext())
+	require.NoError(t, err)
+	_, err = verifier.VerifyAndConsume(context.Background(), envelope, trustedContext())
+	require.ErrorIs(t, err, Replay)
+}
+
+func TestReplayConcurrentConsumersAllowExactlyOne(t *testing.T) {
+	cache := replayCache()
+	entry := replayEntry(2)
+	var successes atomic.Int32
+	errorsByCaller := make(chan error, 64)
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := cache.Consume(context.Background(), entry)
+			if err == nil {
+				successes.Add(1)
+				return
+			}
+			errorsByCaller <- err
+		}()
+	}
+	wg.Wait()
+	close(errorsByCaller)
+	require.Equal(t, int32(1), successes.Load())
+	for err := range errorsByCaller {
+		require.ErrorIs(t, err, Replay)
+	}
+}
+
+func TestReplayCapacityNeverEvictsUnexpiredEntries(t *testing.T) {
+	cache := replayCache()
+	for i := 0; i < MaxReplayEntries; i++ {
+		require.NoError(t, cache.Consume(context.Background(), replayEntry(i)), i)
+	}
+	require.ErrorIs(t, cache.Consume(context.Background(), replayEntry(MaxReplayEntries)), Capacity)
+	require.ErrorIs(t, cache.Consume(context.Background(), replayEntry(0)), Replay)
+}
+
+func TestReplayIdentityExcludesKID(t *testing.T) {
+	cache := replayCache()
+	entry := replayEntry(7)
+	require.NoError(t, cache.Consume(context.Background(), entry))
+	entry.KID = "rotated-kid"
+	require.ErrorIs(t, cache.Consume(context.Background(), entry), Replay)
+}
+
+func TestReplayRetainsThroughExpiryBoundaryThenAllowsReuse(t *testing.T) {
+	now := time.Unix(testNowUnix, 0)
+	cache := NewMemoryReplayConsumer(MaxReplayEntries, func() time.Time { return now })
+	entry := replayEntry(9)
+	entry.ExpiresAt = now
+	require.NoError(t, cache.Consume(context.Background(), entry))
+	require.ErrorIs(t, cache.Consume(context.Background(), entry), Replay)
+	now = now.Add(time.Second)
+	require.NoError(t, cache.Consume(context.Background(), entry))
+}
+
+func replayCache() *MemoryReplayConsumer {
+	return NewMemoryReplayConsumer(MaxReplayEntries, func() time.Time { return time.Unix(testNowUnix, 0) })
+}
+
+func replayEntry(i int) ReplayEntry {
+	jti := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%016d", i)))
+	return ReplayEntry{TrustDomain: "domain", Issuer: "issuer", JTI: jti, KID: "kid", ExpiresAt: time.Unix(testNowUnix+35, 0)}
+}

--- a/bedrockprincipal/schema/connect-sdk-release-manifest.schema.json
+++ b/bedrockprincipal/schema/connect-sdk-release-manifest.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "approval_state", "commit", "source_tree", "tag", "go_module", "corpus_tree", "corpus_digest_sha256", "schema_sha256", "metadata_schema_sha256", "artifact_sha256"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "approval_state": {"enum": ["candidate", "released"]},
+    "commit": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+    "source_tree": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+    "tag": {"type": ["string", "null"], "minLength": 1},
+    "go_module": {"const": "go.minekube.com/connect"},
+    "corpus_tree": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+    "corpus_digest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "schema_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "metadata_schema_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "artifact_sha256": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"approval_state": {"const": "candidate"}}},
+      "then": {"properties": {"commit": {"type": "null"}, "source_tree": {"type": "null"}, "tag": {"type": "null"}, "corpus_tree": {"type": "null"}, "artifact_sha256": {"type": "null"}}},
+      "else": {"properties": {"commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "source_tree": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "tag": {"type": "string", "minLength": 1}, "corpus_tree": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}}}
+    }
+  ]
+}

--- a/bedrockprincipal/schema/metadata-v2.schema.json
+++ b/bedrockprincipal/schema/metadata-v2.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://connect.minekube.com/schema/bedrock-principal/metadata/v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["issuer", "trust_domain", "audience", "cache_max_age_seconds", "keys"],
+  "properties": {
+    "issuer": {"type": "string", "minLength": 1, "maxLength": 128},
+    "trust_domain": {"type": "string", "minLength": 1, "maxLength": 256},
+    "audience": {"type": "string", "minLength": 1, "maxLength": 256},
+    "cache_max_age_seconds": {"type": "integer", "minimum": 1, "maximum": 300},
+    "keys": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 16,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kid", "kty", "crv", "alg", "use", "x", "state"],
+        "properties": {
+          "kid": {"type": "string", "minLength": 1, "maxLength": 128},
+          "kty": {"const": "OKP"},
+          "crv": {"const": "Ed25519"},
+          "alg": {"const": "EdDSA"},
+          "use": {"const": "sig"},
+          "x": {"type": "string", "pattern": "^[A-Za-z0-9_-]{43}$", "minLength": 43, "maxLength": 43},
+          "state": {"enum": ["current", "next", "previous", "revoked", "disabled"]}
+        }
+      }
+    }
+  }
+}

--- a/bedrockprincipal/schema/v2.schema.json
+++ b/bedrockprincipal/schema/v2.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://connect.minekube.com/schema/bedrock-principal/v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "issuer", "trust_domain", "audience", "subject_kind", "canonical_xuid", "canonical_unlinked_uuid", "bedrock_display_name", "endpoint_id", "organization_id", "connect_session_id", "connect_session_nonce", "policy_revision", "source_protocol", "source_protocol_version", "iat", "nbf", "exp", "jti", "verification_method"],
+  "properties": {
+    "version": {"const": 2},
+    "issuer": {"type": "string", "minLength": 1, "maxLength": 128},
+    "trust_domain": {"type": "string", "minLength": 1, "maxLength": 256},
+    "audience": {"type": "string", "minLength": 1, "maxLength": 256},
+    "subject_kind": {"enum": ["bedrock_xuid", "bedrock_linked_java"]},
+    "canonical_xuid": {"type": "string", "pattern": "^[1-9][0-9]{0,18}$", "maxLength": 19},
+    "canonical_unlinked_uuid": {"type": "string", "pattern": "^00000000-0000-0000-[0-9a-f]{4}-[0-9a-f]{12}$", "maxLength": 36},
+    "linked_java": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uuid", "name", "provenance"],
+      "properties": {
+        "uuid": {"type": "string", "format": "uuid", "maxLength": 36},
+        "name": {"type": "string", "pattern": "^[A-Za-z0-9_]{1,16}$", "minLength": 1, "maxLength": 16},
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider", "record_id", "revision", "verified_at"],
+          "properties": {
+            "provider": {"const": "moxy_account_link_v1"},
+            "record_id": {"type": "string", "minLength": 1, "maxLength": 128},
+            "revision": {"type": "integer", "minimum": 1, "maximum": 9223372036854775807},
+            "verified_at": {"type": "integer", "minimum": 0, "maximum": 253402300799}
+          }
+        }
+      }
+    },
+    "bedrock_display_name": {"type": "string", "minLength": 1, "maxLength": 64},
+    "endpoint_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "organization_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "connect_session_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "connect_session_nonce": {"type": "string", "pattern": "^[A-Za-z0-9_-]{22}$", "minLength": 22, "maxLength": 22},
+    "policy_revision": {"type": "integer", "minimum": 1, "maximum": 9223372036854775807},
+    "source_protocol": {"const": "bedrock"},
+    "source_protocol_version": {"type": "integer", "minimum": 1, "maximum": 2147483647},
+    "iat": {"type": "integer", "minimum": 0, "maximum": 253402300799},
+    "nbf": {"type": "integer", "minimum": 0, "maximum": 253402300799},
+    "exp": {"type": "integer", "minimum": 0, "maximum": 253402300799},
+    "jti": {"type": "string", "pattern": "^[A-Za-z0-9_-]{22}$", "minLength": 22, "maxLength": 22},
+    "verification_method": {"enum": ["minecraft_legacy_chain+client_jwt+ecdh_v1", "minecraft_full_jwks+client_jwt+ecdh_v1"]}
+  },
+  "allOf": [
+    {"if": {"properties": {"subject_kind": {"const": "bedrock_xuid"}}}, "then": {"not": {"required": ["linked_java"]}}},
+    {"if": {"properties": {"subject_kind": {"const": "bedrock_linked_java"}}}, "then": {"required": ["linked_java"]}}
+  ]
+}

--- a/bedrockprincipal/schema_test.go
+++ b/bedrockprincipal/schema_test.go
@@ -1,0 +1,56 @@
+package bedrockprincipal_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestV2SchemasAreClosedAndFreezeNonceJTI(t *testing.T) {
+	payload := loadJSONObject(t, "schema/v2.schema.json")
+	require.Equal(t, false, payload["additionalProperties"])
+	properties := payload["properties"].(map[string]any)
+	for _, name := range []string{"connect_session_nonce", "jti"} {
+		property := properties[name].(map[string]any)
+		require.Equal(t, float64(22), property["minLength"], name)
+		require.Equal(t, float64(22), property["maxLength"], name)
+		require.Equal(t, "^[A-Za-z0-9_-]{22}$", property["pattern"], name)
+	}
+	require.Equal(t, float64(1), properties["policy_revision"].(map[string]any)["minimum"])
+
+	metadata := loadJSONObject(t, "schema/metadata-v2.schema.json")
+	require.Equal(t, false, metadata["additionalProperties"])
+	metadataProperties := metadata["properties"].(map[string]any)
+	require.Equal(t, float64(16), metadataProperties["keys"].(map[string]any)["maxItems"])
+	require.Equal(t, float64(300), metadataProperties["cache_max_age_seconds"].(map[string]any)["maximum"])
+}
+
+func TestCoreVectorsHaveOnlyLiteralVerificationInputsAndOutcomes(t *testing.T) {
+	raw, err := os.ReadFile("testdata/v2/core-vectors.json")
+	require.NoError(t, err)
+
+	var vectors []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &vectors))
+	require.NotEmpty(t, vectors)
+	allowed := map[string]bool{
+		"name": true, "compact_jws": true, "trusted_context": true,
+		"verification_time_unix": true, "expected_error": true,
+		"expected_principal": true,
+	}
+	for _, vector := range vectors {
+		for key := range vector {
+			require.True(t, allowed[key], "unexpected vector member %q", key)
+		}
+	}
+}
+
+func loadJSONObject(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var value map[string]any
+	require.NoError(t, json.Unmarshal(raw, &value))
+	return value
+}

--- a/bedrockprincipal/strictjson.go
+++ b/bedrockprincipal/strictjson.go
@@ -1,0 +1,291 @@
+package bedrockprincipal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+func strictObject(raw []byte, target any) error {
+	if !utf8.Valid(raw) || len(raw) > MaxPayloadBytes {
+		return Malformed
+	}
+	if err := validateJSONStringEscapes(raw); err != nil {
+		return err
+	}
+	stringsBytes := 0
+	shape := json.NewDecoder(strings.NewReader(string(raw)))
+	shape.UseNumber()
+	if err := parseStrictObject(shape, 1, &stringsBytes); err != nil {
+		return err
+	}
+	if stringsBytes > 24576 || len(raw)+stringsBytes > 65536 {
+		return Malformed
+	}
+	if token, err := shape.Token(); err != io.EOF || token != nil {
+		return Malformed
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	return ensureJSONEOF(decoder)
+}
+
+func validateJSONStringEscapes(raw []byte) error {
+	inString := false
+	for i := 0; i < len(raw); i++ {
+		switch raw[i] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString || i+1 >= len(raw) {
+				return Malformed
+			}
+			if raw[i+1] != 'u' {
+				i++
+				continue
+			}
+			value, ok := parseHex16(raw, i+2)
+			if !ok {
+				return Malformed
+			}
+			if value >= 0xd800 && value <= 0xdbff {
+				if i+12 > len(raw) || raw[i+6] != '\\' || raw[i+7] != 'u' {
+					return Malformed
+				}
+				low, ok := parseHex16(raw, i+8)
+				if !ok || low < 0xdc00 || low > 0xdfff {
+					return Malformed
+				}
+				i += 11
+				continue
+			}
+			if value >= 0xdc00 && value <= 0xdfff {
+				return Malformed
+			}
+			i += 5
+		}
+	}
+	if inString {
+		return Malformed
+	}
+	return nil
+}
+
+func parseHex16(raw []byte, start int) (uint16, bool) {
+	if start+4 > len(raw) {
+		return 0, false
+	}
+	var result uint16
+	for _, value := range raw[start : start+4] {
+		result <<= 4
+		switch {
+		case value >= '0' && value <= '9':
+			result |= uint16(value - '0')
+		case value >= 'a' && value <= 'f':
+			result |= uint16(value-'a') + 10
+		case value >= 'A' && value <= 'F':
+			result |= uint16(value-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return result, true
+}
+
+func requireObjectMembers(raw []byte, required []string, optional ...string) error {
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &members); err != nil {
+		return Malformed
+	}
+	allowed := make(map[string]bool, len(required)+len(optional))
+	for _, name := range required {
+		allowed[name] = true
+		if _, ok := members[name]; !ok {
+			return Malformed
+		}
+	}
+	for _, name := range optional {
+		allowed[name] = true
+	}
+	for name := range members {
+		if !allowed[name] {
+			return Malformed
+		}
+	}
+	return nil
+}
+
+func rejectDuplicateMembers(raw []byte, maxDepth int) error {
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	first, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if err := validateJSONToken(decoder, first, 1, maxDepth); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return Malformed
+	}
+	return nil
+}
+
+func validateJSONToken(decoder *json.Decoder, token json.Token, depth, maxDepth int) error {
+	if depth > maxDepth {
+		return Malformed
+	}
+	delim, compound := token.(json.Delim)
+	if !compound {
+		if value, ok := token.(string); ok && strings.ContainsRune(value, '\x00') {
+			return Malformed
+		}
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := map[string]bool{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok || seen[key] {
+				return Malformed
+			}
+			seen[key] = true
+			value, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if err := validateJSONToken(decoder, value, depth+1, maxDepth); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return Malformed
+		}
+	case '[':
+		for decoder.More() {
+			value, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if err := validateJSONToken(decoder, value, depth+1, maxDepth); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return Malformed
+		}
+	default:
+		return Malformed
+	}
+	return nil
+}
+
+func parseStrictObject(decoder *json.Decoder, depth int, stringsBytes *int) error {
+	if depth > 4 {
+		return Malformed
+	}
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return Malformed
+	}
+	seen := map[string]struct{}{}
+	members := 0
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return Malformed
+		}
+		key, ok := keyToken.(string)
+		if !ok || strings.ContainsRune(key, '\x00') {
+			return Malformed
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return Malformed
+		}
+		seen[key] = struct{}{}
+		members++
+		if members > 32 {
+			return Malformed
+		}
+		*stringsBytes += len(key)
+		if err := parseStrictValue(decoder, depth, stringsBytes); err != nil {
+			return err
+		}
+	}
+	closing, err := decoder.Token()
+	if err != nil || closing != json.Delim('}') {
+		return Malformed
+	}
+	return nil
+}
+
+func parseStrictValue(decoder *json.Decoder, depth int, stringsBytes *int) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return Malformed
+	}
+	switch value := token.(type) {
+	case json.Delim:
+		if value != '{' {
+			return Malformed
+		}
+		// Token already consumed; parse the object body inline.
+		if depth+1 > 4 {
+			return Malformed
+		}
+		seen := map[string]struct{}{}
+		members := 0
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return Malformed
+			}
+			key, ok := keyToken.(string)
+			if !ok || strings.ContainsRune(key, '\x00') {
+				return Malformed
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return Malformed
+			}
+			seen[key] = struct{}{}
+			members++
+			if members > 32 {
+				return Malformed
+			}
+			*stringsBytes += len(key)
+			if err := parseStrictValue(decoder, depth+1, stringsBytes); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return Malformed
+		}
+	case string:
+		if strings.ContainsRune(value, '\x00') {
+			return Malformed
+		}
+		*stringsBytes += len(value)
+	case json.Number:
+		if strings.ContainsAny(string(value), ".eE") {
+			return Malformed
+		}
+	case bool, nil:
+	default:
+		return fmt.Errorf("unexpected JSON token")
+	}
+	return nil
+}

--- a/bedrockprincipal/strictjson_test.go
+++ b/bedrockprincipal/strictjson_test.go
@@ -1,0 +1,65 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrictEnvelopeRejectsDuplicateUnknownTrailingAndArrayJSON(t *testing.T) {
+	validHeader := `{"alg":"EdDSA","typ":"connect-bedrock-principal+jws;v=2","kid":"connect-v2-test"}`
+	validBody := mustPayloadJSON(t, validPayload())
+	missingVersion := withoutPayloadField(t, validBody, "version")
+	missingIssuer := withoutPayloadField(t, validBody, "issuer")
+	cases := []struct{ name, header, body string }{
+		{"duplicate-header", `{"alg":"EdDSA","alg":"EdDSA","typ":"connect-bedrock-principal+jws;v=2","kid":"connect-v2-test"}`, validBody},
+		{"unknown-header", `{"alg":"EdDSA","typ":"connect-bedrock-principal+jws;v=2","kid":"connect-v2-test","extra":true}`, validBody},
+		{"duplicate-payload", validHeader, strings.Replace(validBody, `"version":2`, `"version":2,"version":2`, 1)},
+		{"unknown-payload", validHeader, strings.TrimSuffix(validBody, "}") + `,"extra":true}`},
+		{"trailing-payload", validHeader, validBody + ` {}`},
+		{"header-array", `[]`, validBody},
+		{"payload-array", validHeader, `[]`},
+		{"nul-string", validHeader, strings.Replace(validBody, "BedrockOne", `Bedrock\u0000One`, 1)},
+		{"unpaired-surrogate", validHeader, strings.Replace(validBody, "BedrockOne", `Bedrock\ud800One`, 1)},
+		{"missing-version", validHeader, missingVersion},
+		{"missing-issuer", validHeader, missingIssuer},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signRaw(tc.header, tc.body)), trustedContext())
+			require.ErrorIs(t, err, Malformed)
+		})
+	}
+}
+
+func signRaw(header, payload string) string {
+	protected := base64.RawURLEncoding.EncodeToString([]byte(header))
+	body := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	input := protected + "." + body
+	signature := ed25519.Sign(testPrivateKey, []byte(input))
+	return input + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func mustPayloadJSON(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	compact := signPayload(t, payload)
+	parts := strings.Split(compact, ".")
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	return string(decoded)
+}
+
+func withoutPayloadField(t *testing.T, body, field string) string {
+	t.Helper()
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &payload))
+	delete(payload, field)
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return string(encoded)
+}

--- a/bedrockprincipal/testdata/compilefail/forged.go
+++ b/bedrockprincipal/testdata/compilefail/forged.go
@@ -1,0 +1,13 @@
+package compilefail
+
+import (
+	"github.com/google/uuid"
+	bp "go.minekube.com/connect/bedrockprincipal"
+)
+
+type forged struct{}
+
+func (forged) SubjectKind() bp.SubjectKind          { return bp.BedrockXUID }
+func (forged) EffectiveGameProfile() bp.GameProfile { return bp.GameProfile{UUID: uuid.Nil} }
+
+var _ bp.VerifiedPrincipal = forged{}

--- a/bedrockprincipal/testdata/v2/connect-sdk-candidate.json
+++ b/bedrockprincipal/testdata/v2/connect-sdk-candidate.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "approval_state": "candidate",
+  "commit": null,
+  "source_tree": null,
+  "tag": null,
+  "go_module": "go.minekube.com/connect",
+  "corpus_tree": null,
+  "corpus_digest_sha256": "ae97581bc658d30b7c5df7493f38c5284847f3a68336259e8ac3a38844a0445a",
+  "schema_sha256": "648677745c5babd03e0e59c1ff5a98cbb0e3a45ab8311632731ee73dd32a807c",
+  "metadata_schema_sha256": "eb92504aee4943144e7d25a5a7dc4fea63429cb848f5cbb6c14fc63254bd1589",
+  "artifact_sha256": null
+}

--- a/bedrockprincipal/testdata/v2/core-vectors.json
+++ b/bedrockprincipal/testdata/v2/core-vectors.json
@@ -1,0 +1,144 @@
+[
+  {
+    "name": "valid-unlinked",
+    "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzAsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQVFFQkFRRUJBUUVCQVFFQkFRRUJBUSIsIm5iZiI6MTc4NTQ5MjAwMCwib3JnYW5pemF0aW9uX2lkIjoib3JnYW5pemF0aW9uLXRlc3QiLCJwb2xpY3lfcmV2aXNpb24iOjcsInNvdXJjZV9wcm90b2NvbCI6ImJlZHJvY2siLCJzb3VyY2VfcHJvdG9jb2xfdmVyc2lvbiI6Nzc2LCJzdWJqZWN0X2tpbmQiOiJiZWRyb2NrX3h1aWQiLCJ0cnVzdF9kb21haW4iOiJ1cm46bWluZWt1YmU6Y29ubmVjdDp0ZXN0OmNvcnB1cy12MiIsInZlcmlmaWNhdGlvbl9tZXRob2QiOiJtaW5lY3JhZnRfbGVnYWN5X2NoYWluK2NsaWVudF9qd3QrZWNkaF92MSIsInZlcnNpb24iOjJ9.QmT-XuIYP3fbeVvsG1HzGKZXSyETGMBr3F8snZH_vssZoijXE2VsUDESRVm9bcS1aXAGQPqlo5nv8ZsYWAq1DQ",
+    "trusted_context": {
+      "issuer": "minekube-connect-test",
+      "trust_domain": "urn:minekube:connect:test:corpus-v2",
+      "audience": "urn:minekube:connect:test:bedrock-principal:v2",
+      "endpoint_id": "endpoint-test",
+      "organization_id": "organization-test",
+      "connect_session_id": "session-test",
+      "connect_session_nonce": "AAAAAAAAAAAAAAAAAAAAAA",
+      "source_protocol": "bedrock",
+      "source_protocol_version": 776,
+      "policy_revision": 7
+    },
+    "verification_time_unix": 1785492000,
+    "expected_error": "OK",
+    "expected_principal": {
+      "subject_kind": "bedrock_xuid",
+      "canonical_xuid": "1",
+      "canonical_unlinked_uuid": "00000000-0000-0000-0000-000000000001",
+      "bedrock_display_name": "BedrockOne",
+      "effective_uuid": "00000000-0000-0000-0000-000000000001",
+      "effective_name": "BedrockOne",
+      "verification_method": "minecraft_legacy_chain+client_jwt+ecdh_v1",
+      "kid": "connect-v2-test",
+      "policy_revision": 7
+    }
+  },
+  {
+    "name": "valid-linked",
+    "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzAsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZyIsImxpbmtlZF9qYXZhIjp7Im5hbWUiOiJKYXZhT25lIiwicHJvdmVuYW5jZSI6eyJwcm92aWRlciI6Im1veHlfYWNjb3VudF9saW5rX3YxIiwicmVjb3JkX2lkIjoicmVjb3JkLXRlc3QtMSIsInJldmlzaW9uIjozLCJ2ZXJpZmllZF9hdCI6MTc4NTQ5MTk5MH0sInV1aWQiOiIxMjNlNDU2Ny1lODliLTEyZDMtYTQ1Ni00MjY2MTQxNzQwMDAifSwibmJmIjoxNzg1NDkyMDAwLCJvcmdhbml6YXRpb25faWQiOiJvcmdhbml6YXRpb24tdGVzdCIsInBvbGljeV9yZXZpc2lvbiI6Nywic291cmNlX3Byb3RvY29sIjoiYmVkcm9jayIsInNvdXJjZV9wcm90b2NvbF92ZXJzaW9uIjo3NzYsInN1YmplY3Rfa2luZCI6ImJlZHJvY2tfbGlua2VkX2phdmEiLCJ0cnVzdF9kb21haW4iOiJ1cm46bWluZWt1YmU6Y29ubmVjdDp0ZXN0OmNvcnB1cy12MiIsInZlcmlmaWNhdGlvbl9tZXRob2QiOiJtaW5lY3JhZnRfZnVsbF9qd2tzK2NsaWVudF9qd3QrZWNkaF92MSIsInZlcnNpb24iOjJ9.IRUZUa5XfbSD8JUMQoAEBlXn7emo23CsSFpscvJAvDqHDl_t7GxfmilrtGbfWOAAqWpJc4N5a9F1Z2xBJW3MDw",
+    "trusted_context": {
+      "issuer": "minekube-connect-test",
+      "trust_domain": "urn:minekube:connect:test:corpus-v2",
+      "audience": "urn:minekube:connect:test:bedrock-principal:v2",
+      "endpoint_id": "endpoint-test",
+      "organization_id": "organization-test",
+      "connect_session_id": "session-test",
+      "connect_session_nonce": "AAAAAAAAAAAAAAAAAAAAAA",
+      "source_protocol": "bedrock",
+      "source_protocol_version": 776,
+      "policy_revision": 7
+    },
+    "verification_time_unix": 1785492000,
+    "expected_error": "OK",
+    "expected_principal": {
+      "subject_kind": "bedrock_linked_java",
+      "canonical_xuid": "1",
+      "canonical_unlinked_uuid": "00000000-0000-0000-0000-000000000001",
+      "bedrock_display_name": "BedrockOne",
+      "effective_uuid": "123e4567-e89b-12d3-a456-426614174000",
+      "effective_name": "JavaOne",
+      "verification_method": "minecraft_full_jwks+client_jwt+ecdh_v1",
+      "kid": "connect-v2-test",
+      "policy_revision": 7,
+      "linked_java": {
+        "uuid": "123e4567-e89b-12d3-a456-426614174000",
+        "name": "JavaOne",
+        "provider": "moxy_account_link_v1",
+        "record_id": "record-test-1",
+        "revision": 3,
+        "verified_at_unix": 1785491990
+      }
+    }
+  },
+  {
+    "name": "malformed-jti-tail-bits",
+    "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzAsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQUFBQUFBQUFBQUFBQUFBQUFBQUFBQiIsIm5iZiI6MTc4NTQ5MjAwMCwib3JnYW5pemF0aW9uX2lkIjoib3JnYW5pemF0aW9uLXRlc3QiLCJwb2xpY3lfcmV2aXNpb24iOjcsInNvdXJjZV9wcm90b2NvbCI6ImJlZHJvY2siLCJzb3VyY2VfcHJvdG9jb2xfdmVyc2lvbiI6Nzc2LCJzdWJqZWN0X2tpbmQiOiJiZWRyb2NrX3h1aWQiLCJ0cnVzdF9kb21haW4iOiJ1cm46bWluZWt1YmU6Y29ubmVjdDp0ZXN0OmNvcnB1cy12MiIsInZlcmlmaWNhdGlvbl9tZXRob2QiOiJtaW5lY3JhZnRfbGVnYWN5X2NoYWluK2NsaWVudF9qd3QrZWNkaF92MSIsInZlcnNpb24iOjJ9.ixTwonoVJy6lhy3OOyyvQ3SOBhZRziaCNsIiOQtJjLTLt6sepLVE_d0urHww2aorNhHxa427FNelaIb9YTABDQ",
+    "trusted_context": {
+      "issuer": "minekube-connect-test",
+      "trust_domain": "urn:minekube:connect:test:corpus-v2",
+      "audience": "urn:minekube:connect:test:bedrock-principal:v2",
+      "endpoint_id": "endpoint-test",
+      "organization_id": "organization-test",
+      "connect_session_id": "session-test",
+      "connect_session_nonce": "AAAAAAAAAAAAAAAAAAAAAA",
+      "source_protocol": "bedrock",
+      "source_protocol_version": 776,
+      "policy_revision": 7
+    },
+    "verification_time_unix": 1785492000,
+    "expected_error": "MALFORMED",
+    "expected_principal": null
+  },
+  {
+    "name": "policy-revision-mismatch",
+    "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzAsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQkFRRUJBUUVCQVFFQkFRRUJBUUVCQSIsIm5iZiI6MTc4NTQ5MjAwMCwib3JnYW5pemF0aW9uX2lkIjoib3JnYW5pemF0aW9uLXRlc3QiLCJwb2xpY3lfcmV2aXNpb24iOjcsInNvdXJjZV9wcm90b2NvbCI6ImJlZHJvY2siLCJzb3VyY2VfcHJvdG9jb2xfdmVyc2lvbiI6Nzc2LCJzdWJqZWN0X2tpbmQiOiJiZWRyb2NrX3h1aWQiLCJ0cnVzdF9kb21haW4iOiJ1cm46bWluZWt1YmU6Y29ubmVjdDp0ZXN0OmNvcnB1cy12MiIsInZlcmlmaWNhdGlvbl9tZXRob2QiOiJtaW5lY3JhZnRfbGVnYWN5X2NoYWluK2NsaWVudF9qd3QrZWNkaF92MSIsInZlcnNpb24iOjJ9.3CBE3q1423w7COZr3nOmPPG6p8Q5R-UoKT_5ge4mHfWcGbLWL740phPKItjcul6jQg6wfZVeKDaSdGv0VNGvDA",
+    "trusted_context": {
+      "issuer": "minekube-connect-test",
+      "trust_domain": "urn:minekube:connect:test:corpus-v2",
+      "audience": "urn:minekube:connect:test:bedrock-principal:v2",
+      "endpoint_id": "endpoint-test",
+      "organization_id": "organization-test",
+      "connect_session_id": "session-test",
+      "connect_session_nonce": "AAAAAAAAAAAAAAAAAAAAAA",
+      "source_protocol": "bedrock",
+      "source_protocol_version": 776,
+      "policy_revision": 8
+    },
+    "verification_time_unix": 1785492000,
+    "expected_error": "BINDING_MISMATCH",
+    "expected_principal": null
+  },
+  {
+    "name": "lifetime-thirty-one",
+    "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzEsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQlFVRkJRVUZCUVVGQlFVRkJRVUZCUSIsIm5iZiI6MTc4NTQ5MjAwMCwib3JnYW5pemF0aW9uX2lkIjoib3JnYW5pemF0aW9uLXRlc3QiLCJwb2xpY3lfcmV2aXNpb24iOjcsInNvdXJjZV9wcm90b2NvbCI6ImJlZHJvY2siLCJzb3VyY2VfcHJvdG9jb2xfdmVyc2lvbiI6Nzc2LCJzdWJqZWN0X2tpbmQiOiJiZWRyb2NrX3h1aWQiLCJ0cnVzdF9kb21haW4iOiJ1cm46bWluZWt1YmU6Y29ubmVjdDp0ZXN0OmNvcnB1cy12MiIsInZlcmlmaWNhdGlvbl9tZXRob2QiOiJtaW5lY3JhZnRfbGVnYWN5X2NoYWluK2NsaWVudF9qd3QrZWNkaF92MSIsInZlcnNpb24iOjJ9.neB1VaIdiZm1Nov9WsAAMW4R0AuC8vYOV7O3TyLK-dH262xWy6dsiv33gKq3JfK8aiEtBlotfey4IRLH6cM0Cw",
+    "trusted_context": {
+      "issuer": "minekube-connect-test",
+      "trust_domain": "urn:minekube:connect:test:corpus-v2",
+      "audience": "urn:minekube:connect:test:bedrock-principal:v2",
+      "endpoint_id": "endpoint-test",
+      "organization_id": "organization-test",
+      "connect_session_id": "session-test",
+      "connect_session_nonce": "AAAAAAAAAAAAAAAAAAAAAA",
+      "source_protocol": "bedrock",
+      "source_protocol_version": 776,
+      "policy_revision": 7
+    },
+    "verification_time_unix": 1785492000,
+    "expected_error": "TIME",
+    "expected_principal": null
+  },
+  {
+    "name": "tampered-signature",
+    "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzAsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQmdZR0JnWUdCZ1lHQmdZR0JnWUdCZyIsIm5iZiI6MTc4NTQ5MjAwMCwib3JnYW5pemF0aW9uX2lkIjoib3JnYW5pemF0aW9uLXRlc3QiLCJwb2xpY3lfcmV2aXNpb24iOjcsInNvdXJjZV9wcm90b2NvbCI6ImJlZHJvY2siLCJzb3VyY2VfcHJvdG9jb2xfdmVyc2lvbiI6Nzc2LCJzdWJqZWN0X2tpbmQiOiJiZWRyb2NrX3h1aWQiLCJ0cnVzdF9kb21haW4iOiJ1cm46bWluZWt1YmU6Y29ubmVjdDp0ZXN0OmNvcnB1cy12MiIsInZlcmlmaWNhdGlvbl9tZXRob2QiOiJtaW5lY3JhZnRfbGVnYWN5X2NoYWluK2NsaWVudF9qd3QrZWNkaF92MSIsInZlcnNpb24iOjJ9.B1gHheFVnd1Wa4-6OpCOdi0xLO-N2qdm_jKuPKXoxHqJI701x82b9G0rnoo2SYWuLkayE9vvwk7V9K2CNgnKDA",
+    "trusted_context": {
+      "issuer": "minekube-connect-test",
+      "trust_domain": "urn:minekube:connect:test:corpus-v2",
+      "audience": "urn:minekube:connect:test:bedrock-principal:v2",
+      "endpoint_id": "endpoint-test",
+      "organization_id": "organization-test",
+      "connect_session_id": "session-test",
+      "connect_session_nonce": "AAAAAAAAAAAAAAAAAAAAAA",
+      "source_protocol": "bedrock",
+      "source_protocol_version": 776,
+      "policy_revision": 7
+    },
+    "verification_time_unix": 1785492000,
+    "expected_error": "SIGNATURE",
+    "expected_principal": null
+  }
+]

--- a/bedrockprincipal/types.go
+++ b/bedrockprincipal/types.go
@@ -1,0 +1,116 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"crypto/ed25519"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	WireType            = "connect-bedrock-principal+jws;v=2"
+	Capability          = "bedrock-verified-principal-v2"
+	MaxEnvelopeBytes    = 16 << 10
+	MaxHeaderBytes      = 2 << 10
+	MaxPayloadBytes     = 12 << 10
+	MaxReplayEntries    = 65536
+	MaxEnvelopeLifetime = 30 * time.Second
+	ClockSkew           = 5 * time.Second
+)
+
+type PrincipalError string
+
+func (e PrincipalError) Error() string { return string(e) }
+
+const (
+	Malformed           PrincipalError = "MALFORMED"
+	Trust               PrincipalError = "TRUST"
+	Signature           PrincipalError = "SIGNATURE"
+	BindingMismatch     PrincipalError = "BINDING_MISMATCH"
+	TimeInvalid         PrincipalError = "TIME"
+	IdentityInvalid     PrincipalError = "IDENTITY"
+	LinkInvalid         PrincipalError = "LINK"
+	Replay              PrincipalError = "REPLAY"
+	Capacity            PrincipalError = "CAPACITY"
+	MetadataUnavailable PrincipalError = "METADATA_UNAVAILABLE"
+	KeyRevoked          PrincipalError = "KEY_REVOKED"
+	Readiness           PrincipalError = "READINESS"
+	Internal            PrincipalError = "INTERNAL"
+)
+
+type SubjectKind string
+
+const (
+	BedrockXUID       SubjectKind = "bedrock_xuid"
+	BedrockLinkedJava SubjectKind = "bedrock_linked_java"
+)
+
+type CanonicalXUID string
+
+type GameProfile struct {
+	UUID uuid.UUID
+	Name string
+}
+
+type LinkProvenance struct {
+	Provider   string
+	RecordID   string
+	Revision   int64
+	VerifiedAt time.Time
+}
+
+type VerifiedLinkedJavaIdentity struct {
+	UUID       uuid.UUID
+	Name       string
+	Provenance LinkProvenance
+}
+
+type VerificationEvidence struct {
+	KID                string
+	VerificationMethod string
+	IssuedAt           time.Time
+	NotBefore          time.Time
+	ExpiresAt          time.Time
+}
+
+type PrincipalBindings struct {
+	Issuer                string
+	TrustDomain           string
+	Audience              string
+	EndpointID            string
+	OrganizationID        string
+	ConnectSessionID      string
+	ConnectSessionNonce   [16]byte
+	SourceProtocol        string
+	SourceProtocolVersion int32
+	PolicyRevision        int64
+}
+
+type TrustedProposalContext = PrincipalBindings
+
+type SignedPrincipalEnvelope struct{ compact string }
+
+func NewSignedPrincipalEnvelope(compact []byte) (SignedPrincipalEnvelope, error) {
+	if len(compact) == 0 || len(compact) > MaxEnvelopeBytes {
+		return SignedPrincipalEnvelope{}, Malformed
+	}
+	return SignedPrincipalEnvelope{compact: string(append([]byte(nil), compact...))}, nil
+}
+
+func (e SignedPrincipalEnvelope) bytes() []byte { return []byte(e.compact) }
+
+type KeyProvider interface {
+	Eligible(context.Context, string, string) (ed25519.PublicKey, error)
+}
+
+type ReplayConsumer interface {
+	Consume(context.Context, ReplayEntry) error
+}
+
+type VerifierConfiguration struct {
+	Keys        map[string]ed25519.PublicKey
+	KeyProvider KeyProvider
+	Replay      ReplayConsumer
+	Now         func() time.Time
+}

--- a/bedrockprincipal/types.go
+++ b/bedrockprincipal/types.go
@@ -98,8 +98,6 @@ func NewSignedPrincipalEnvelope(compact []byte) (SignedPrincipalEnvelope, error)
 	return SignedPrincipalEnvelope{compact: string(append([]byte(nil), compact...))}, nil
 }
 
-func (e SignedPrincipalEnvelope) bytes() []byte { return []byte(e.compact) }
-
 type KeyProvider interface {
 	Eligible(context.Context, string, string) (ed25519.PublicKey, error)
 }

--- a/bedrockprincipal/verifier.go
+++ b/bedrockprincipal/verifier.go
@@ -12,6 +12,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const maxUnixTimestamp = int64(253402300799)
+
 type Verifier interface {
 	VerifyAndConsume(context.Context, SignedPrincipalEnvelope, TrustedProposalContext) (VerifiedBedrockPrincipal, error)
 }
@@ -197,7 +199,7 @@ func decodeCanonical16(value string) ([16]byte, error) {
 
 func validateTime(claims payloadClaims, now int64) error {
 	for _, value := range []int64{claims.IAT, claims.NBF, claims.EXP} {
-		if value < 0 || value > 253402300799 {
+		if value < 0 || value > maxUnixTimestamp {
 			return TimeInvalid
 		}
 	}
@@ -216,8 +218,8 @@ func principalFromClaims(claims payloadClaims, kid string, bindings PrincipalBin
 	if err != nil || xuid == 0 || xuid > math.MaxInt64 {
 		return nil, IdentityInvalid
 	}
-	unlinked, err := uuid.Parse(claims.CanonicalUnlinkedUUID)
-	if err != nil || unlinked != uuidFromXUID(xuid) {
+	unlinked, ok := parseCanonicalUUID(claims.CanonicalUnlinkedUUID)
+	if !ok || unlinked != uuidFromXUID(xuid) {
 		return nil, IdentityInvalid
 	}
 	if claims.BedrockDisplayName == "" || len(claims.BedrockDisplayName) > 64 {
@@ -237,8 +239,8 @@ func principalFromClaims(claims payloadClaims, kid string, bindings PrincipalBin
 		if claims.LinkedJava == nil {
 			return nil, LinkInvalid
 		}
-		linkedUUID, err := uuid.Parse(claims.LinkedJava.UUID)
-		if err != nil || claims.LinkedJava.Name == "" || len(claims.LinkedJava.Name) > 16 || claims.LinkedJava.Provenance.Provider != "moxy_account_link_v1" || claims.LinkedJava.Provenance.RecordID == "" || claims.LinkedJava.Provenance.Revision <= 0 {
+		linkedUUID, ok := parseCanonicalUUID(claims.LinkedJava.UUID)
+		if !ok || !validJavaName(claims.LinkedJava.Name) || claims.LinkedJava.Provenance.Provider != "moxy_account_link_v1" || claims.LinkedJava.Provenance.RecordID == "" || len(claims.LinkedJava.Provenance.RecordID) > 128 || claims.LinkedJava.Provenance.Revision <= 0 || claims.LinkedJava.Provenance.VerifiedAt < 0 || claims.LinkedJava.Provenance.VerifiedAt > maxUnixTimestamp {
 			return nil, LinkInvalid
 		}
 		p.linked = VerifiedLinkedJavaIdentity{UUID: linkedUUID, Name: claims.LinkedJava.Name, Provenance: LinkProvenance{Provider: claims.LinkedJava.Provenance.Provider, RecordID: claims.LinkedJava.Provenance.RecordID, Revision: claims.LinkedJava.Provenance.Revision, VerifiedAt: time.Unix(claims.LinkedJava.Provenance.VerifiedAt, 0)}}
@@ -247,6 +249,30 @@ func principalFromClaims(claims payloadClaims, kid string, bindings PrincipalBin
 		return nil, IdentityInvalid
 	}
 	return p, nil
+}
+
+func parseCanonicalUUID(value string) (uuid.UUID, bool) {
+	if len(value) != 36 {
+		return uuid.Nil, false
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil || parsed.String() != value {
+		return uuid.Nil, false
+	}
+	return parsed, true
+}
+
+func validJavaName(value string) bool {
+	if len(value) == 0 || len(value) > 16 {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		char := value[i]
+		if !((char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 func uuidFromXUID(xuid uint64) uuid.UUID {

--- a/bedrockprincipal/verifier.go
+++ b/bedrockprincipal/verifier.go
@@ -1,0 +1,259 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Verifier interface {
+	VerifyAndConsume(context.Context, SignedPrincipalEnvelope, TrustedProposalContext) (VerifiedBedrockPrincipal, error)
+}
+
+type verifier struct {
+	keys   KeyProvider
+	replay ReplayConsumer
+	now    func() time.Time
+}
+
+type staticKeys map[string]ed25519.PublicKey
+
+func (s staticKeys) Eligible(_ context.Context, _ string, kid string) (ed25519.PublicKey, error) {
+	key, ok := s[kid]
+	if !ok {
+		return nil, Trust
+	}
+	return append(ed25519.PublicKey(nil), key...), nil
+}
+
+func NewVerifier(configuration VerifierConfiguration) Verifier {
+	provider := configuration.KeyProvider
+	if provider == nil {
+		provider = staticKeys(configuration.Keys)
+	}
+	now := configuration.Now
+	if now == nil {
+		now = time.Now
+	}
+	replay := configuration.Replay
+	if replay == nil {
+		replay = NewMemoryReplayConsumer(MaxReplayEntries, now)
+	}
+	return &verifier{keys: provider, replay: replay, now: now}
+}
+
+type protectedHeader struct {
+	Alg string `json:"alg"`
+	Typ string `json:"typ"`
+	KID string `json:"kid"`
+}
+
+type payloadClaims struct {
+	Version               int               `json:"version"`
+	Issuer                string            `json:"issuer"`
+	TrustDomain           string            `json:"trust_domain"`
+	Audience              string            `json:"audience"`
+	SubjectKind           SubjectKind       `json:"subject_kind"`
+	CanonicalXUID         string            `json:"canonical_xuid"`
+	CanonicalUnlinkedUUID string            `json:"canonical_unlinked_uuid"`
+	LinkedJava            *linkedJavaClaims `json:"linked_java,omitempty"`
+	BedrockDisplayName    string            `json:"bedrock_display_name"`
+	EndpointID            string            `json:"endpoint_id"`
+	OrganizationID        string            `json:"organization_id"`
+	ConnectSessionID      string            `json:"connect_session_id"`
+	ConnectSessionNonce   string            `json:"connect_session_nonce"`
+	PolicyRevision        int64             `json:"policy_revision"`
+	SourceProtocol        string            `json:"source_protocol"`
+	SourceProtocolVersion int32             `json:"source_protocol_version"`
+	IAT                   int64             `json:"iat"`
+	NBF                   int64             `json:"nbf"`
+	EXP                   int64             `json:"exp"`
+	JTI                   string            `json:"jti"`
+	VerificationMethod    string            `json:"verification_method"`
+}
+
+type linkedJavaClaims struct {
+	UUID       string               `json:"uuid"`
+	Name       string               `json:"name"`
+	Provenance linkProvenanceClaims `json:"provenance"`
+}
+
+type linkProvenanceClaims struct {
+	Provider   string `json:"provider"`
+	RecordID   string `json:"record_id"`
+	Revision   int64  `json:"revision"`
+	VerifiedAt int64  `json:"verified_at"`
+}
+
+func (v *verifier) VerifyAndConsume(ctx context.Context, env SignedPrincipalEnvelope, expected TrustedProposalContext) (VerifiedBedrockPrincipal, error) {
+	header, claims, signingInput, signature, err := parseEnvelope(env)
+	if err != nil {
+		return nil, Malformed
+	}
+	if claims.Issuer != expected.Issuer || claims.TrustDomain != expected.TrustDomain || claims.Audience != expected.Audience {
+		return nil, Trust
+	}
+	key, err := v.keys.Eligible(ctx, expected.TrustDomain, header.KID)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) != ed25519.PublicKeySize || !ed25519.Verify(key, signingInput, signature) {
+		return nil, Signature
+	}
+	nonce, err := decodeCanonical16(claims.ConnectSessionNonce)
+	if err != nil {
+		return nil, Malformed
+	}
+	if _, err := decodeCanonical16(claims.JTI); err != nil {
+		return nil, Malformed
+	}
+	if nonce != expected.ConnectSessionNonce || claims.EndpointID != expected.EndpointID ||
+		claims.OrganizationID != expected.OrganizationID || claims.ConnectSessionID != expected.ConnectSessionID ||
+		claims.SourceProtocol != expected.SourceProtocol || claims.SourceProtocolVersion != expected.SourceProtocolVersion ||
+		claims.PolicyRevision != expected.PolicyRevision || expected.PolicyRevision <= 0 {
+		return nil, BindingMismatch
+	}
+	if err := validateTime(claims, v.now().Unix()); err != nil {
+		return nil, err
+	}
+	principal, err := principalFromClaims(claims, header.KID, expected)
+	if err != nil {
+		return nil, err
+	}
+	if err := v.replay.Consume(ctx, ReplayEntry{TrustDomain: claims.TrustDomain, Issuer: claims.Issuer, JTI: claims.JTI, KID: header.KID, EndpointID: claims.EndpointID, SessionID: claims.ConnectSessionID, SessionNonce: nonce, ExpiresAt: time.Unix(claims.EXP+5, 0)}); err != nil {
+		return nil, err
+	}
+	return principal, nil
+}
+
+func parseEnvelope(env SignedPrincipalEnvelope) (protectedHeader, payloadClaims, []byte, []byte, error) {
+	parts := strings.Split(env.compact, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return protectedHeader{}, payloadClaims{}, nil, nil, Malformed
+	}
+	headerBytes, err := decodeCanonical(parts[0], MaxHeaderBytes)
+	if err != nil {
+		return protectedHeader{}, payloadClaims{}, nil, nil, err
+	}
+	payloadBytes, err := decodeCanonical(parts[1], MaxPayloadBytes)
+	if err != nil {
+		return protectedHeader{}, payloadClaims{}, nil, nil, err
+	}
+	signature, err := decodeCanonical(parts[2], ed25519.SignatureSize)
+	if err != nil || len(signature) != ed25519.SignatureSize {
+		return protectedHeader{}, payloadClaims{}, nil, nil, Malformed
+	}
+	var header protectedHeader
+	if err := strictObject(headerBytes, &header); err != nil || header.Alg != "EdDSA" || header.Typ != WireType || header.KID == "" || len(header.KID) > 128 {
+		return protectedHeader{}, payloadClaims{}, nil, nil, Malformed
+	}
+	if err := requireObjectMembers(headerBytes, []string{"alg", "typ", "kid"}); err != nil {
+		return protectedHeader{}, payloadClaims{}, nil, nil, Malformed
+	}
+	var claims payloadClaims
+	if err := strictObject(payloadBytes, &claims); err != nil {
+		return protectedHeader{}, payloadClaims{}, nil, nil, Malformed
+	}
+	if err := requireObjectMembers(payloadBytes, []string{
+		"version", "issuer", "trust_domain", "audience", "subject_kind", "canonical_xuid",
+		"canonical_unlinked_uuid", "bedrock_display_name", "endpoint_id", "organization_id",
+		"connect_session_id", "connect_session_nonce", "policy_revision", "source_protocol",
+		"source_protocol_version", "iat", "nbf", "exp", "jti", "verification_method",
+	}, "linked_java"); err != nil {
+		return protectedHeader{}, payloadClaims{}, nil, nil, Malformed
+	}
+	return header, claims, []byte(parts[0] + "." + parts[1]), signature, nil
+}
+
+func decodeCanonical(value string, maxDecoded int) ([]byte, error) {
+	if strings.Contains(value, "=") {
+		return nil, Malformed
+	}
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(value)
+	if err != nil || len(decoded) > maxDecoded || base64.RawURLEncoding.EncodeToString(decoded) != value {
+		return nil, Malformed
+	}
+	return decoded, nil
+}
+
+func decodeCanonical16(value string) ([16]byte, error) {
+	var result [16]byte
+	if len(value) != 22 {
+		return result, Malformed
+	}
+	decoded, err := decodeCanonical(value, 16)
+	if err != nil || len(decoded) != 16 {
+		return result, Malformed
+	}
+	copy(result[:], decoded)
+	return result, nil
+}
+
+func validateTime(claims payloadClaims, now int64) error {
+	for _, value := range []int64{claims.IAT, claims.NBF, claims.EXP} {
+		if value < 0 || value > 253402300799 {
+			return TimeInvalid
+		}
+	}
+	if claims.NBF > claims.IAT || claims.IAT > claims.EXP || claims.EXP-claims.IAT > 30 ||
+		claims.NBF > now+5 || claims.IAT > now+5 || claims.EXP < now-5 {
+		return TimeInvalid
+	}
+	return nil
+}
+
+func principalFromClaims(claims payloadClaims, kid string, bindings PrincipalBindings) (VerifiedBedrockPrincipal, error) {
+	if claims.Version != 2 || claims.CanonicalXUID == "" || len(claims.CanonicalXUID) > 19 || claims.CanonicalXUID[0] == '0' {
+		return nil, IdentityInvalid
+	}
+	xuid, err := strconv.ParseUint(claims.CanonicalXUID, 10, 63)
+	if err != nil || xuid == 0 || xuid > math.MaxInt64 {
+		return nil, IdentityInvalid
+	}
+	unlinked, err := uuid.Parse(claims.CanonicalUnlinkedUUID)
+	if err != nil || unlinked != uuidFromXUID(xuid) {
+		return nil, IdentityInvalid
+	}
+	if claims.BedrockDisplayName == "" || len(claims.BedrockDisplayName) > 64 {
+		return nil, IdentityInvalid
+	}
+	if claims.VerificationMethod != "minecraft_legacy_chain+client_jwt+ecdh_v1" && claims.VerificationMethod != "minecraft_full_jwks+client_jwt+ecdh_v1" {
+		return nil, IdentityInvalid
+	}
+	p := &verifiedBedrockPrincipal{kind: claims.SubjectKind, xuid: CanonicalXUID(claims.CanonicalXUID), unlinkedUUID: unlinked, displayName: claims.BedrockDisplayName, bindings: bindings,
+		verification: VerificationEvidence{KID: kid, VerificationMethod: claims.VerificationMethod, IssuedAt: time.Unix(claims.IAT, 0), NotBefore: time.Unix(claims.NBF, 0), ExpiresAt: time.Unix(claims.EXP, 0)}}
+	switch claims.SubjectKind {
+	case BedrockXUID:
+		if claims.LinkedJava != nil {
+			return nil, LinkInvalid
+		}
+	case BedrockLinkedJava:
+		if claims.LinkedJava == nil {
+			return nil, LinkInvalid
+		}
+		linkedUUID, err := uuid.Parse(claims.LinkedJava.UUID)
+		if err != nil || claims.LinkedJava.Name == "" || len(claims.LinkedJava.Name) > 16 || claims.LinkedJava.Provenance.Provider != "moxy_account_link_v1" || claims.LinkedJava.Provenance.RecordID == "" || claims.LinkedJava.Provenance.Revision <= 0 {
+			return nil, LinkInvalid
+		}
+		p.linked = VerifiedLinkedJavaIdentity{UUID: linkedUUID, Name: claims.LinkedJava.Name, Provenance: LinkProvenance{Provider: claims.LinkedJava.Provenance.Provider, RecordID: claims.LinkedJava.Provenance.RecordID, Revision: claims.LinkedJava.Provenance.Revision, VerifiedAt: time.Unix(claims.LinkedJava.Provenance.VerifiedAt, 0)}}
+		p.hasLinked = true
+	default:
+		return nil, IdentityInvalid
+	}
+	return p, nil
+}
+
+func uuidFromXUID(xuid uint64) uuid.UUID {
+	var id uuid.UUID
+	for i := 15; i >= 8; i-- {
+		id[i] = byte(xuid)
+		xuid >>= 8
+	}
+	return id
+}

--- a/bedrockprincipal/verifier.go
+++ b/bedrockprincipal/verifier.go
@@ -115,7 +115,9 @@ func (v *verifier) VerifyAndConsume(ctx context.Context, env SignedPrincipalEnve
 	if _, err := decodeCanonical16(claims.JTI); err != nil {
 		return nil, Malformed
 	}
-	if nonce != expected.ConnectSessionNonce || claims.EndpointID != expected.EndpointID ||
+	if !validBedrockBinding(claims.SourceProtocol, claims.SourceProtocolVersion, claims.EndpointID, claims.OrganizationID, claims.ConnectSessionID) ||
+		!validBedrockBinding(expected.SourceProtocol, expected.SourceProtocolVersion, expected.EndpointID, expected.OrganizationID, expected.ConnectSessionID) ||
+		nonce != expected.ConnectSessionNonce || claims.EndpointID != expected.EndpointID ||
 		claims.OrganizationID != expected.OrganizationID || claims.ConnectSessionID != expected.ConnectSessionID ||
 		claims.SourceProtocol != expected.SourceProtocol || claims.SourceProtocolVersion != expected.SourceProtocolVersion ||
 		claims.PolicyRevision != expected.PolicyRevision || expected.PolicyRevision <= 0 {
@@ -132,6 +134,14 @@ func (v *verifier) VerifyAndConsume(ctx context.Context, env SignedPrincipalEnve
 		return nil, err
 	}
 	return principal, nil
+}
+
+func validBedrockBinding(sourceProtocol string, sourceProtocolVersion int32, endpointID, organizationID, connectSessionID string) bool {
+	return sourceProtocol == "bedrock" && sourceProtocolVersion >= 1 && validBindingID(endpointID) && validBindingID(organizationID) && validBindingID(connectSessionID)
+}
+
+func validBindingID(value string) bool {
+	return len(value) >= 1 && len(value) <= 128
 }
 
 func parseEnvelope(env SignedPrincipalEnvelope) (protectedHeader, payloadClaims, []byte, []byte, error) {

--- a/bedrockprincipal/verifier_test.go
+++ b/bedrockprincipal/verifier_test.go
@@ -105,6 +105,46 @@ func TestVerifierEnforcesLinkedJavaSchemaBounds(t *testing.T) {
 	}
 }
 
+func TestVerifierEnforcesFrozenBedrockBindingSchema(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(map[string]any, *TrustedProposalContext)
+	}{
+		{name: "source-protocol", mutate: func(payload map[string]any, context *TrustedProposalContext) {
+			payload["source_protocol"] = "java"
+			context.SourceProtocol = "java"
+		}},
+		{name: "source-protocol-version", mutate: func(payload map[string]any, context *TrustedProposalContext) {
+			payload["source_protocol_version"] = int32(0)
+			context.SourceProtocolVersion = 0
+		}},
+		{name: "endpoint-id-length", mutate: func(payload map[string]any, context *TrustedProposalContext) {
+			value := strings.Repeat("e", 129)
+			payload["endpoint_id"] = value
+			context.EndpointID = value
+		}},
+		{name: "organization-id-length", mutate: func(payload map[string]any, context *TrustedProposalContext) {
+			value := strings.Repeat("o", 129)
+			payload["organization_id"] = value
+			context.OrganizationID = value
+		}},
+		{name: "connect-session-id-length", mutate: func(payload map[string]any, context *TrustedProposalContext) {
+			value := strings.Repeat("s", 129)
+			payload["connect_session_id"] = value
+			context.ConnectSessionID = value
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := validPayload()
+			expectedContext := trustedContext()
+			tc.mutate(payload, &expectedContext)
+			_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, payload)), expectedContext)
+			require.ErrorIs(t, err, BindingMismatch)
+		})
+	}
+}
+
 func TestNonceAndJTIRequireCanonicalSixteenByteBase64URL(t *testing.T) {
 	encode := base64.RawURLEncoding.EncodeToString
 	cases := []struct {

--- a/bedrockprincipal/verifier_test.go
+++ b/bedrockprincipal/verifier_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -272,9 +271,4 @@ func mustEnvelope(t *testing.T, compact string) SignedPrincipalEnvelope {
 	envelope, err := NewSignedPrincipalEnvelope([]byte(compact))
 	require.NoError(t, err)
 	return envelope
-}
-
-func requirePrincipalError(t *testing.T, err error, want PrincipalError) {
-	t.Helper()
-	require.True(t, errors.Is(err, want), "got %v, want %s", err, want)
 }

--- a/bedrockprincipal/verifier_test.go
+++ b/bedrockprincipal/verifier_test.go
@@ -49,6 +49,62 @@ func TestVerifyReturnsTypedUnlinkedPrincipal(t *testing.T) {
 	require.Equal(t, int64(7), principal.Bindings().PolicyRevision)
 }
 
+func TestVerifierRequiresCanonicalUUIDSpelling(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(map[string]any)
+		want   PrincipalError
+	}{
+		{name: "unlinked-braced", mutate: func(payload map[string]any) {
+			payload["canonical_unlinked_uuid"] = "{00000000-0000-0000-0000-000000000001}"
+		}, want: IdentityInvalid},
+		{name: "linked-uppercase", mutate: func(payload map[string]any) {
+			payload = linkedPayload(payload)
+			linked := payload["linked_java"].(map[string]any)
+			linked["uuid"] = "123E4567-E89B-12D3-A456-426614174000"
+		}, want: LinkInvalid},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := validPayload()
+			tc.mutate(payload)
+			_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, payload)), trustedContext())
+			require.ErrorIs(t, err, tc.want)
+		})
+	}
+}
+
+func TestVerifierEnforcesLinkedJavaSchemaBounds(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "name-character-set", mutate: func(payload map[string]any) {
+			payload["linked_java"].(map[string]any)["name"] = "Java One"
+		}},
+		{name: "name-length", mutate: func(payload map[string]any) {
+			payload["linked_java"].(map[string]any)["name"] = strings.Repeat("J", 17)
+		}},
+		{name: "record-id-length", mutate: func(payload map[string]any) {
+			payload["linked_java"].(map[string]any)["provenance"].(map[string]any)["record_id"] = strings.Repeat("r", 129)
+		}},
+		{name: "verified-at-before-epoch", mutate: func(payload map[string]any) {
+			payload["linked_java"].(map[string]any)["provenance"].(map[string]any)["verified_at"] = int64(-1)
+		}},
+		{name: "verified-at-after-maximum", mutate: func(payload map[string]any) {
+			payload["linked_java"].(map[string]any)["provenance"].(map[string]any)["verified_at"] = int64(253402300800)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := linkedPayload(validPayload())
+			tc.mutate(payload)
+			_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, payload)), trustedContext())
+			require.ErrorIs(t, err, LinkInvalid)
+		})
+	}
+}
+
 func TestNonceAndJTIRequireCanonicalSixteenByteBase64URL(t *testing.T) {
 	encode := base64.RawURLEncoding.EncodeToString
 	cases := []struct {
@@ -143,6 +199,20 @@ func validPayload() map[string]any {
 		"iat": testNowUnix, "nbf": testNowUnix, "exp": testNowUnix + 30, "jti": testJTI,
 		"verification_method": "minecraft_legacy_chain+client_jwt+ecdh_v1",
 	}
+}
+
+func linkedPayload(payload map[string]any) map[string]any {
+	payload["subject_kind"] = "bedrock_linked_java"
+	payload["verification_method"] = "minecraft_full_jwks+client_jwt+ecdh_v1"
+	payload["linked_java"] = map[string]any{
+		"uuid": "123e4567-e89b-12d3-a456-426614174000",
+		"name": "JavaOne",
+		"provenance": map[string]any{
+			"provider": "moxy_account_link_v1", "record_id": "record-test-1",
+			"revision": int64(3), "verified_at": testNowUnix - 10,
+		},
+	}
+	return payload
 }
 
 func signPayload(t *testing.T, payload map[string]any) string {

--- a/bedrockprincipal/verifier_test.go
+++ b/bedrockprincipal/verifier_test.go
@@ -1,0 +1,170 @@
+package bedrockprincipal
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testNowUnix = int64(1785492000)
+	testNonce   = "AAAAAAAAAAAAAAAAAAAAAA"
+	testJTI     = "AQEBAQEBAQEBAQEBAQEBAQ"
+)
+
+var (
+	testSeed       = sha256.Sum256([]byte("connect-bedrock-principal-v2-test-only"))
+	testPrivateKey = ed25519.NewKeyFromSeed(testSeed[:])
+	testPublicKey  = testPrivateKey.Public().(ed25519.PublicKey)
+)
+
+func TestPrincipalCannotBeConstructedOutsideVerifier(t *testing.T) {
+	cmd := exec.Command("go", "test", "./testdata/compilefail")
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(out), "verifiedPrincipal")
+}
+
+func TestVerifyReturnsTypedUnlinkedPrincipal(t *testing.T) {
+	payload := validPayload()
+	principal, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, payload)), trustedContext())
+	require.NoError(t, err)
+	require.Equal(t, BedrockXUID, principal.SubjectKind())
+	require.Equal(t, CanonicalXUID("1"), principal.XUID())
+	require.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), principal.CanonicalUnlinkedUUID())
+	_, linked := principal.LinkedJava()
+	require.False(t, linked)
+	require.Equal(t, GameProfile{UUID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), Name: "BedrockOne"}, principal.EffectiveGameProfile())
+	require.Equal(t, int64(7), principal.Bindings().PolicyRevision)
+}
+
+func TestNonceAndJTIRequireCanonicalSixteenByteBase64URL(t *testing.T) {
+	encode := base64.RawURLEncoding.EncodeToString
+	cases := []struct {
+		name  string
+		field string
+		value string
+	}{
+		{name: "nonce-15-decoded-bytes", field: "connect_session_nonce", value: encode(make([]byte, 15))},
+		{name: "nonce-17-decoded-bytes", field: "connect_session_nonce", value: encode(make([]byte, 17))},
+		{name: "jti-21-characters", field: "jti", value: strings.Repeat("A", 21)},
+		{name: "jti-23-characters", field: "jti", value: strings.Repeat("A", 23)},
+		{name: "nonce-padding", field: "connect_session_nonce", value: testNonce + "=="},
+		{name: "jti-standard-alphabet", field: "jti", value: strings.Repeat("A", 21) + "+"},
+		{name: "jti-nonzero-tail-bits", field: "jti", value: strings.Repeat("A", 21) + "B"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := validPayload()
+			payload[tc.field] = tc.value
+			_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, payload)), trustedContext())
+			require.ErrorIs(t, err, Malformed)
+		})
+	}
+}
+
+func TestNonceClaimMustMatchTrustedContextBytes(t *testing.T) {
+	ctx := trustedContext()
+	ctx.ConnectSessionNonce[15] = 1
+	_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, validPayload())), ctx)
+	require.ErrorIs(t, err, BindingMismatch)
+}
+
+func TestLifetimeAndSkewEqualityBoundaries(t *testing.T) {
+	cases := []struct {
+		name          string
+		iat, nbf, exp int64
+		want          PrincipalError
+	}{
+		{name: "now-plus-five-equals-nbf", iat: testNowUnix + 5, nbf: testNowUnix + 5, exp: testNowUnix + 30},
+		{name: "now-minus-five-equals-exp", iat: testNowUnix - 35, nbf: testNowUnix - 35, exp: testNowUnix - 5},
+		{name: "iat-equals-now-plus-five", iat: testNowUnix + 5, nbf: testNowUnix, exp: testNowUnix + 30},
+		{name: "lifetime-equals-thirty", iat: testNowUnix, nbf: testNowUnix, exp: testNowUnix + 30},
+		{name: "nbf-one-second-outside", iat: testNowUnix + 6, nbf: testNowUnix + 6, exp: testNowUnix + 30, want: TimeInvalid},
+		{name: "exp-one-second-outside", iat: testNowUnix - 36, nbf: testNowUnix - 36, exp: testNowUnix - 6, want: TimeInvalid},
+		{name: "iat-one-second-outside", iat: testNowUnix + 6, nbf: testNowUnix, exp: testNowUnix + 30, want: TimeInvalid},
+		{name: "lifetime-one-second-outside", iat: testNowUnix, nbf: testNowUnix, exp: testNowUnix + 31, want: TimeInvalid},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := validPayload()
+			payload["iat"], payload["nbf"], payload["exp"] = tc.iat, tc.nbf, tc.exp
+			payload["jti"] = base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%016d", i)))
+			_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, payload)), trustedContext())
+			if tc.want == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.want)
+			}
+		})
+	}
+}
+
+func verifierAt(now int64) Verifier {
+	return NewVerifier(VerifierConfiguration{
+		Keys:   map[string]ed25519.PublicKey{"connect-v2-test": testPublicKey},
+		Replay: NewMemoryReplayConsumer(65536, func() time.Time { return time.Unix(now, 0) }),
+		Now:    func() time.Time { return time.Unix(now, 0) },
+	})
+}
+
+func trustedContext() TrustedProposalContext {
+	return TrustedProposalContext{
+		Issuer: "minekube-connect-test", TrustDomain: "urn:minekube:connect:test:corpus-v2",
+		Audience: "urn:minekube:connect:test:bedrock-principal:v2", EndpointID: "endpoint-test",
+		OrganizationID: "organization-test", ConnectSessionID: "session-test",
+		ConnectSessionNonce: [16]byte{}, SourceProtocol: "bedrock", SourceProtocolVersion: 776,
+		PolicyRevision: 7,
+	}
+}
+
+func validPayload() map[string]any {
+	return map[string]any{
+		"version": 2, "issuer": "minekube-connect-test",
+		"trust_domain": "urn:minekube:connect:test:corpus-v2",
+		"audience":     "urn:minekube:connect:test:bedrock-principal:v2",
+		"subject_kind": "bedrock_xuid", "canonical_xuid": "1",
+		"canonical_unlinked_uuid": "00000000-0000-0000-0000-000000000001",
+		"bedrock_display_name":    "BedrockOne", "endpoint_id": "endpoint-test",
+		"organization_id": "organization-test", "connect_session_id": "session-test",
+		"connect_session_nonce": testNonce, "policy_revision": 7,
+		"source_protocol": "bedrock", "source_protocol_version": 776,
+		"iat": testNowUnix, "nbf": testNowUnix, "exp": testNowUnix + 30, "jti": testJTI,
+		"verification_method": "minecraft_legacy_chain+client_jwt+ecdh_v1",
+	}
+}
+
+func signPayload(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	header := []byte(`{"alg":"EdDSA","typ":"connect-bedrock-principal+jws;v=2","kid":"connect-v2-test"}`)
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+	protected := base64.RawURLEncoding.EncodeToString(header)
+	body := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	input := protected + "." + body
+	signature := ed25519.Sign(testPrivateKey, []byte(input))
+	return input + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func mustEnvelope(t *testing.T, compact string) SignedPrincipalEnvelope {
+	t.Helper()
+	envelope, err := NewSignedPrincipalEnvelope([]byte(compact))
+	require.NoError(t, err)
+	return envelope
+}
+
+func requirePrincipalError(t *testing.T, err error, want PrincipalError) {
+	t.Helper()
+	require.True(t, errors.Is(err, want), "got %v, want %s", err, want)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.1
 require (
 	buf.build/gen/go/minekube/connect/protocolbuffers/go v1.32.0-20230517110945-04c17e7d2fd9.1
 	github.com/coder/websocket v1.8.12
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231212172506-995d672761c0
 	google.golang.org/grpc v1.59.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=


### PR DESCRIPTION
## Intent

Implement the captain-approved Bedrock Option A v2 signed-principal protocol corpus for minekube/connect from clean main at a96c1963, following spec commit 78754829 and checkpoint-1 correlation 3b2db3b29d50b1ac, but replacing the frozen abandoned generalized reference-model/oracle architecture with the scout-approved smaller proof architecture: a small literal core-vectors corpus, deterministic signing-only regeneration, direct repository-local nonce/JTI, exact lifetime/skew, replay concurrency/capacity, structural descriptor/observability, strict verifier, metadata, readiness, and verifier-only typed principal proofs. Nonce and JTI are exactly 16 random bytes represented by canonical unpadded 22-character base64url; lifetime is at most 30 seconds with inclusive five-second skew; policy revision is signed and trusted-context-bound. Preserve the hard prohibition on reference_context, generalized action/state engines, concurrency winner prediction, generalized semantic loaders, and generalized privacy vocabulary registration. Keep final Watch/libp2p wire consumption explicitly gated on bedrock-option-a-moxy-wire-source and do not invent generated versions. Source/interface work only: no secrets, credentials, endpoints, releases, production claims, Moxy PR #511, or kunchenguid repositories.

## What Changed

- Added the Bedrock Option A v2 signed-principal types, strict schema validation, verifier, metadata, readiness, and typed principal proofs.
- Added deterministic signing/vector tooling and coverage for nonce/JTI encoding, lifetime/skew, replay, linked provenance, descriptors, and observability.
- Added protocol schemas and repository-local Bedrock/Java test fixtures.

## Risk Assessment

✅ Low: The latest target addresses the three prior findings, and no additional material source defect was substantiated in the full diff review.

## Testing

Targeted Bedrock principal tests, deterministic corpus regeneration, replay race/capacity checks, and verbose literal core-vector verification passed. Evidence transcripts were captured, the wire-source gate was confirmed, and the worktree remained free of transient artifacts.

<details>
<summary>Evidence: Deterministic corpus regeneration</summary>

`core vectors regenerate exactly`

```text
core vectors regenerate exactly
```
</details>
<details>
<summary>Evidence: Literal core-vector verification</summary>

```text
=== RUN   TestCoreVectorsVerifyAgainstLiteralOutcomes
=== RUN   TestCoreVectorsVerifyAgainstLiteralOutcomes/valid-unlinked
=== RUN   TestCoreVectorsVerifyAgainstLiteralOutcomes/valid-linked
=== RUN   TestCoreVectorsVerifyAgainstLiteralOutcomes/malformed-jti-tail-bits
=== RUN   TestCoreVectorsVerifyAgainstLiteralOutcomes/policy-revision-mismatch
=== RUN   TestCoreVectorsVerifyAgainstLiteralOutcomes/lifetime-thirty-one
=== RUN   TestCoreVectorsVerifyAgainstLiteralOutcomes/tampered-signature
--- PASS: TestCoreVectorsVerifyAgainstLiteralOutcomes (0.01s)
    --- PASS: TestCoreVectorsVerifyAgainstLiteralOutcomes/valid-unlinked (0.00s)
    --- PASS: TestCoreVectorsVerifyAgainstLiteralOutcomes/valid-linked (0.00s)
    --- PASS: TestCoreVectorsVerifyAgainstLiteralOutcomes/malformed-jti-tail-bits (0.00s)
    --- PASS: TestCoreVectorsVerifyAgainstLiteralOutcomes/policy-revision-mismatch (0.00s)
    --- PASS: TestCoreVectorsVerifyAgainstLiteralOutcomes/lifetime-thirty-one (0.00s)
    --- PASS: TestCoreVectorsVerifyAgainstLiteralOutcomes/tampered-signature (0.00s)
PASS
ok  	go.minekube.com/connect/bedrockprincipal	0.311s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bedrockprincipal/metadata.go:69` - The production origin pin conflicts with the requirement “no ... endpoints” and hardcodes `https://connect.minekube.com` in this source-only branch.
- 🚨 `bedrockprincipal/verifier.go:219` - The verifier accepts off-schema identity claims because `uuid.Parse` is permissive and linked fields lack schema bounds/format checks. Enforce canonical UUID spelling and nested field constraints before constructing the principal.
- ⚠️ `bedrockprincipal/internal/descriptorprivacy/validate.go:36` - The descriptor validator checks only number, name, and scalar type, so incompatible labels such as repeated fields can pass an “exact” frozen contract.
- ⚠️ `bedrockprincipal/core_vector_test.go:74` - The corpus test pads or truncates decoded trusted-context nonces instead of requiring exactly 16 bytes and canonical encoding, weakening the nonce invariant.
- ⚠️ `bedrockprincipal/core_vector_test.go:64` - Expected `LinkedJava` data is never compared, so incorrect link provenance could pass the core corpus as long as the effective UUID and name match.

🔧 Fix: Hardened UUID, descriptor, nonce, and linked provenance validation
3 issues (1 error, 2 warnings) still open:
- 🚨 `bedrockprincipal/verifier.go:118` - The verifier only equality-binds source fields to the caller context; it never enforces the Bedrock schema. A signed payload with `source_protocol` set to `java`, version `0`, or overlong bound IDs passes when the trusted context matches, despite the schema requiring Bedrock, version &gt;=1, and bounded IDs. Validate these at the VerifyAndConsume binding boundary.
- ⚠️ `bedrockprincipal/metadata.go:74` - When no HTTP client is supplied, the constructor type-asserts `http.DefaultTransport` to `*http.Transport`. Applications that install an instrumented or custom `http.RoundTripper` will panic during provider construction; handle non-`*http.Transport` defaults without panicking.
- ⚠️ `bedrockprincipal/core_vector_test.go:110` - The core corpus now checks linked Java fields, but still never compares `BedrockDisplayName`. For linked principals, an incorrect Bedrock display name can regress while the corpus passes because only the effective Java profile is checked.

🔧 Fix: Hardened binding validation, transport fallback, and corpus coverage
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./bedrockprincipal/... -count=1`
- `go run ./bedrockprincipal/internal/vectorcmd --check bedrockprincipal/testdata/v2/core-vectors.json`
- `go test -race ./bedrockprincipal -run 'TestReplayConcurrentConsumersAllowExactlyOne|TestReplayCapacityNeverEvictsUnexpiredEntries|TestVerifierConsumesSameEnvelopeAsOKThenReplay' -count=1`
- `go test -v ./bedrockprincipal -run 'TestCoreVectorsVerifyAgainstLiteralOutcomes' -count=1`
- `Scoped forbidden-architecture and wire-gate audit`
- `git diff --check a96c1963d0e3bffc90341b82c8febd9f8e00b654 070459700b6a5eacbe54536ecf7b24de59558cdd`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
