### PR TITLE
feat(geyserliteabi): complete authenticated subprocess ABI

### DIFF
--- a/geyserliteabi/SUBPROCESS_FRAMING.md
+++ b/geyserliteabi/SUBPROCESS_FRAMING.md
@@ -12,21 +12,67 @@ bootstrap is:
 version_u8=1 || generation_u64_be || ipc_key_32
 ```
 
-Every authenticated packet is at most 8192 bytes, carries the generation, uses
-a sequence beginning at one and increasing exactly, and ends in a 32-byte
-HMAC-SHA256. Integers are unsigned big-endian. Assignment is:
+The bootstrap is exactly 41 bytes. Every authenticated packet is at most 8192
+bytes, carries the generation, uses a sequence beginning at one and increasing
+exactly, and ends in a 32-byte HMAC-SHA256 over every preceding packet byte.
+Integers are unsigned big-endian. The common authenticated prefix is exactly 26
+bytes:
+
+| Field | Offset | Size |
+| --- | ---: | ---: |
+| version (`1`) | 0 | 1 |
+| type | 1 | 1 |
+| generation | 2 | 8 |
+| sequence | 10 | 8 |
+| connection handle | 18 | 8 |
+
+Assignment is type 1 and remains exactly 82 bytes:
 
 ```text
 version=1 || type=1 || generation_u64_be || sequence_u64_be || connection_handle_u64_be || correlation_16 || expires_unix_ms_u64_be || HMAC-SHA256
 ```
 
-The child acknowledges with `type=2` and the same generation, handle, and
-correlation. Verified ingress uses `type=3`, repeats the generation and handle,
-and carries the existing bounded `VerifiedIngressV1` payload. The correlation
-is exactly 16 bytes, the ingress frame is 1–4096 bytes, and its expiry is at
-most five seconds after callback.
+Its correlation begins at offset 26, expiry at offset 42, and MAC at offset 50.
+
+The child acknowledges with type 2 and the same generation, handle, and
+correlation. ACK is exactly 75 bytes:
+
+```text
+version=1 || type=2 || generation_u64_be || sequence_u64_be || connection_handle_u64_be || correlation_16 || status_u8 || HMAC-SHA256
+```
+
+The correlation remains at its original offset 26. Status is appended at offset
+42: `0` is a positive ACK and `1` is a negative ACK. The MAC begins at offset
+43 and authenticates the status. A missing status, any other status value, or
+any packet length other than 75 is invalid and fail-closed. A negative ACK
+closes the transport and clears the pending assignment.
+
+Verified ingress uses type 3, repeats the generation and handle, and carries the
+existing bounded `VerifiedIngressV1` payload:
+
+```text
+version=1 || type=3 || generation_u64_be || sequence_u64_be || connection_handle_u64_be || verified_ingress_v1_proto_1_to_4096 || HMAC-SHA256
+```
+
+The payload begins at offset 26; because `SOCK_SEQPACKET` preserves the packet
+boundary, the MAC is the final 32 bytes. The packet is 59–4154 bytes. The
+correlation inside `VerifiedIngressV1` is exactly 16 bytes, the ingress frame is
+1–4096 bytes, and its expiry is at most five seconds after callback.
+
+The child publishes a newly minted, nonzero connection handle with type 4
+before translation or authentication. Connection-open is exactly 58 bytes:
+
+```text
+version=1 || type=4 || generation_u64_be || sequence_u64_be || connection_handle_u64_be || HMAC-SHA256
+```
+
+Its MAC begins at offset 26. A connection-open packet carries no correlation:
+after accepting the authenticated event, Gate creates the 16-byte correlation
+and binds it to the exact `(generation, connection_handle)` in the subsequent
+type-1 assignment. GeyserLite must not release the connection until it has sent
+a positive type-2 ACK for that same generation, handle, and correlation.
 
 MAC or peer-owner failure, sequence gap/reuse, stale generation, unknown or
-duplicate handle/correlation, expiry, EOF, restart, or backlog overflow is
-fail-closed and clears pending state. The IPC key is never placed in arguments,
-environment, disk, logs, or artifacts.
+duplicate/reused handle or correlation, expiry, EOF, restart, or backlog
+overflow is fail-closed and clears pending state. The IPC key is never placed
+in arguments, environment, disk, logs, or artifacts.

--- a/geyserliteabi/abi.go
+++ b/geyserliteabi/abi.go
@@ -34,9 +34,10 @@ const (
 	SubprocessACKPositive uint8 = 0
 	SubprocessACKNegative uint8 = 1
 
-	SubprocessIPCKeyBytes       = 32
-	SubprocessMACBytes          = 32
-	MaxAuthenticatedPacketBytes = 8192
+	SubprocessBootstrapPacketBytes = 41
+	SubprocessIPCKeyBytes          = 32
+	SubprocessMACBytes             = 32
+	MaxAuthenticatedPacketBytes    = 8192
 )
 
 // Authenticated subprocess packet byte offsets and exact or bounded sizes.

--- a/geyserliteabi/abi.go
+++ b/geyserliteabi/abi.go
@@ -29,8 +29,39 @@ const (
 	SubprocessAssignment      uint8 = 1
 	SubprocessAssignmentACK   uint8 = 2
 	SubprocessVerifiedIngress uint8 = 3
+	SubprocessConnectionOpen  uint8 = 4
+
+	SubprocessACKPositive uint8 = 0
+	SubprocessACKNegative uint8 = 1
 
 	SubprocessIPCKeyBytes       = 32
 	SubprocessMACBytes          = 32
 	MaxAuthenticatedPacketBytes = 8192
+)
+
+// Authenticated subprocess packet byte offsets and exact or bounded sizes.
+// The ACK status is appended after the existing correlation field so every
+// pre-existing type-2 field retains its frozen offset.
+const (
+	SubprocessVersionOffset          = 0
+	SubprocessTypeOffset             = 1
+	SubprocessGenerationOffset       = 2
+	SubprocessSequenceOffset         = 10
+	SubprocessConnectionHandleOffset = 18
+	SubprocessCorrelationOffset      = 26
+
+	SubprocessAssignmentExpiresOffset = 42
+	SubprocessAssignmentMACOffset     = 50
+	SubprocessAssignmentPacketBytes   = 82
+
+	SubprocessAssignmentACKStatusOffset = 42
+	SubprocessAssignmentACKMACOffset    = 43
+	SubprocessAssignmentACKPacketBytes  = 75
+
+	SubprocessVerifiedIngressPayloadOffset  = 26
+	MinSubprocessVerifiedIngressPacketBytes = 59
+	MaxSubprocessVerifiedIngressPacketBytes = 4154
+
+	SubprocessConnectionOpenMACOffset   = 26
+	SubprocessConnectionOpenPacketBytes = 58
 )

--- a/geyserliteabi/abi_test.go
+++ b/geyserliteabi/abi_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -65,22 +66,61 @@ func TestNativeHeaderFreezesCallbackABI(t *testing.T) {
 	require.Contains(t, header, "validate pointers and frame_len before reading native memory")
 	require.Contains(t, header, "Java/native owns callback memory after return")
 	for _, definition := range []string{
-		"GEYSERLITE_INGRESS_CORRELATION_BYTES 16",
-		"GEYSERLITE_INGRESS_FRAME_MAX_BYTES 4096",
-		"GEYSERLITE_INGRESS_LIFETIME_MAX_MS 5000",
-		"GEYSERLITE_ASSIGN_UNKNOWN_OR_CLOSED_HANDLE -1",
-		"GEYSERLITE_ASSIGN_DUPLICATE_HANDLE_OR_CORRELATION -2",
-		"GEYSERLITE_ASSIGN_INVALID_OR_EXPIRED_TIME -3",
-		"GEYSERLITE_ASSIGN_WRONG_CONNECTION_STATE -4",
-		"GEYSERLITE_SUBPROCESS_CONNECTION_OPEN 4",
-		"GEYSERLITE_SUBPROCESS_ACK_POSITIVE 0",
-		"GEYSERLITE_SUBPROCESS_ACK_NEGATIVE 1",
-		"GEYSERLITE_SUBPROCESS_ACK_STATUS_OFFSET 42",
-		"GEYSERLITE_SUBPROCESS_ACK_PACKET_BYTES 75",
-		"GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_PACKET_BYTES 58",
+		"GEYSERLITE_SUBPROCESS_ASSIGNMENT_PACKET_BYTES 82",
+		"GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_MIN_PACKET_BYTES 59",
+		"GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_MAX_PACKET_BYTES 4154",
 	} {
 		require.Contains(t, header, definition)
 	}
+
+	expected := map[string]int64{
+		"GEYSERLITE_CALLBACK_ABI_VERSION":                         int64(CallbackABIVersion),
+		"GEYSERLITE_INGRESS_CORRELATION_BYTES":                    int64(CorrelationBytes),
+		"GEYSERLITE_INGRESS_FRAME_MIN_BYTES":                      int64(MinIngressFrameBytes),
+		"GEYSERLITE_INGRESS_FRAME_MAX_BYTES":                      int64(MaxIngressFrameBytes),
+		"GEYSERLITE_INGRESS_LIFETIME_MAX_MS":                      MaxIngressLifetime.Milliseconds(),
+		"GEYSERLITE_CALLBACK_REGISTRATION_OK":                     int64(CallbackRegistrationOK),
+		"GEYSERLITE_ASSIGN_OK":                                    int64(AssignmentOK),
+		"GEYSERLITE_ASSIGN_UNKNOWN_OR_CLOSED_HANDLE":              int64(AssignmentUnknownOrClosedHandle),
+		"GEYSERLITE_ASSIGN_DUPLICATE_HANDLE_OR_CORRELATION":       int64(AssignmentDuplicateHandleOrCorrelation),
+		"GEYSERLITE_ASSIGN_INVALID_OR_EXPIRED_TIME":               int64(AssignmentInvalidOrExpiredTime),
+		"GEYSERLITE_ASSIGN_WRONG_CONNECTION_STATE":                int64(AssignmentWrongConnectionState),
+		"GEYSERLITE_SUBPROCESS_FRAME_VERSION":                     int64(SubprocessFrameVersion),
+		"GEYSERLITE_SUBPROCESS_ASSIGNMENT":                        int64(SubprocessAssignment),
+		"GEYSERLITE_SUBPROCESS_ASSIGNMENT_ACK":                    int64(SubprocessAssignmentACK),
+		"GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS":                  int64(SubprocessVerifiedIngress),
+		"GEYSERLITE_SUBPROCESS_CONNECTION_OPEN":                   int64(SubprocessConnectionOpen),
+		"GEYSERLITE_SUBPROCESS_ACK_POSITIVE":                      int64(SubprocessACKPositive),
+		"GEYSERLITE_SUBPROCESS_ACK_NEGATIVE":                      int64(SubprocessACKNegative),
+		"GEYSERLITE_SUBPROCESS_BOOTSTRAP_PACKET_BYTES":            int64(SubprocessBootstrapPacketBytes),
+		"GEYSERLITE_SUBPROCESS_IPC_KEY_BYTES":                     int64(SubprocessIPCKeyBytes),
+		"GEYSERLITE_SUBPROCESS_MAC_BYTES":                         int64(SubprocessMACBytes),
+		"GEYSERLITE_SUBPROCESS_MAX_PACKET_BYTES":                  int64(MaxAuthenticatedPacketBytes),
+		"GEYSERLITE_SUBPROCESS_VERSION_OFFSET":                    int64(SubprocessVersionOffset),
+		"GEYSERLITE_SUBPROCESS_TYPE_OFFSET":                       int64(SubprocessTypeOffset),
+		"GEYSERLITE_SUBPROCESS_GENERATION_OFFSET":                 int64(SubprocessGenerationOffset),
+		"GEYSERLITE_SUBPROCESS_SEQUENCE_OFFSET":                   int64(SubprocessSequenceOffset),
+		"GEYSERLITE_SUBPROCESS_CONNECTION_HANDLE_OFFSET":          int64(SubprocessConnectionHandleOffset),
+		"GEYSERLITE_SUBPROCESS_CORRELATION_OFFSET":                int64(SubprocessCorrelationOffset),
+		"GEYSERLITE_SUBPROCESS_ASSIGNMENT_EXPIRES_OFFSET":         int64(SubprocessAssignmentExpiresOffset),
+		"GEYSERLITE_SUBPROCESS_ASSIGNMENT_MAC_OFFSET":             int64(SubprocessAssignmentMACOffset),
+		"GEYSERLITE_SUBPROCESS_ASSIGNMENT_PACKET_BYTES":           int64(SubprocessAssignmentPacketBytes),
+		"GEYSERLITE_SUBPROCESS_ACK_STATUS_OFFSET":                 int64(SubprocessAssignmentACKStatusOffset),
+		"GEYSERLITE_SUBPROCESS_ACK_MAC_OFFSET":                    int64(SubprocessAssignmentACKMACOffset),
+		"GEYSERLITE_SUBPROCESS_ACK_PACKET_BYTES":                  int64(SubprocessAssignmentACKPacketBytes),
+		"GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_PAYLOAD_OFFSET":   int64(SubprocessVerifiedIngressPayloadOffset),
+		"GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_MIN_PACKET_BYTES": int64(MinSubprocessVerifiedIngressPacketBytes),
+		"GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_MAX_PACKET_BYTES": int64(MaxSubprocessVerifiedIngressPacketBytes),
+		"GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_MAC_OFFSET":        int64(SubprocessConnectionOpenMACOffset),
+		"GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_PACKET_BYTES":      int64(SubprocessConnectionOpenPacketBytes),
+	}
+	actual := make(map[string]int64)
+	for _, match := range regexp.MustCompile(`(?m)^#define (GEYSERLITE_[A-Z0-9_]+) (-?[0-9]+)\s*$`).FindAllStringSubmatch(string(raw), -1) {
+		value, err := strconv.ParseInt(match[2], 10, 64)
+		require.NoError(t, err)
+		actual[match[1]] = value
+	}
+	require.Equal(t, expected, actual)
 }
 
 func TestSubprocessFramingConstants(t *testing.T) {
@@ -91,11 +131,27 @@ func TestSubprocessFramingConstants(t *testing.T) {
 	require.Equal(t, uint8(4), SubprocessConnectionOpen)
 	require.Equal(t, uint8(0), SubprocessACKPositive)
 	require.Equal(t, uint8(1), SubprocessACKNegative)
+	require.Equal(t, 41, SubprocessBootstrapPacketBytes)
 	require.Equal(t, 32, SubprocessIPCKeyBytes)
 	require.Equal(t, 32, SubprocessMACBytes)
 	require.Equal(t, 8192, MaxAuthenticatedPacketBytes)
-	require.Equal(t, 58, SubprocessConnectionOpenPacketBytes)
+	require.Equal(t, 0, SubprocessVersionOffset)
+	require.Equal(t, 1, SubprocessTypeOffset)
+	require.Equal(t, 2, SubprocessGenerationOffset)
+	require.Equal(t, 10, SubprocessSequenceOffset)
+	require.Equal(t, 18, SubprocessConnectionHandleOffset)
+	require.Equal(t, 26, SubprocessCorrelationOffset)
+	require.Equal(t, 42, SubprocessAssignmentExpiresOffset)
+	require.Equal(t, 50, SubprocessAssignmentMACOffset)
+	require.Equal(t, 82, SubprocessAssignmentPacketBytes)
+	require.Equal(t, 42, SubprocessAssignmentACKStatusOffset)
+	require.Equal(t, 43, SubprocessAssignmentACKMACOffset)
 	require.Equal(t, 75, SubprocessAssignmentACKPacketBytes)
+	require.Equal(t, 26, SubprocessVerifiedIngressPayloadOffset)
+	require.Equal(t, 59, MinSubprocessVerifiedIngressPacketBytes)
+	require.Equal(t, 4154, MaxSubprocessVerifiedIngressPacketBytes)
+	require.Equal(t, 26, SubprocessConnectionOpenMACOffset)
+	require.Equal(t, 58, SubprocessConnectionOpenPacketBytes)
 
 	raw, err := os.ReadFile("SUBPROCESS_FRAMING.md")
 	require.NoError(t, err)
@@ -220,7 +276,11 @@ func TestExistingSubprocessPacketWireEncodingRemainsFrozen(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.hex, hex.EncodeToString(encodeSubprocessTestPacket(t, key, tt.packet)))
+			wire := encodeSubprocessTestPacket(t, key, tt.packet)
+			require.Equal(t, tt.hex, hex.EncodeToString(wire))
+			if tt.packet.packetType == SubprocessAssignment {
+				require.Len(t, wire, SubprocessAssignmentPacketBytes)
+			}
 		})
 	}
 
@@ -238,6 +298,23 @@ func TestExistingSubprocessPacketWireEncodingRemainsFrozen(t *testing.T) {
 		"0102010203040506070811121314151617182122232425262728303132333435363738393a3b3c3d3e3f",
 		hex.EncodeToString(positiveACK[:SubprocessAssignmentACKStatusOffset]),
 	)
+}
+
+func TestSubprocessVerifiedIngressPacketBounds(t *testing.T) {
+	require.Equal(t, SubprocessVerifiedIngressPayloadOffset+MinIngressFrameBytes+SubprocessMACBytes, MinSubprocessVerifiedIngressPacketBytes)
+	require.Equal(t, SubprocessVerifiedIngressPayloadOffset+MaxIngressFrameBytes+SubprocessMACBytes, MaxSubprocessVerifiedIngressPacketBytes)
+
+	key := subprocessTestKey()
+	for _, frameBytes := range []int{MinIngressFrameBytes, MaxIngressFrameBytes} {
+		wire := encodeSubprocessTestPacket(t, key, subprocessTestPacket{
+			packetType:       SubprocessVerifiedIngress,
+			generation:       1,
+			sequence:         1,
+			connectionHandle: 1,
+			payload:          make([]byte, frameBytes),
+		})
+		require.Len(t, wire, SubprocessVerifiedIngressPayloadOffset+frameBytes+SubprocessMACBytes)
+	}
 }
 
 var (

--- a/geyserliteabi/abi_test.go
+++ b/geyserliteabi/abi_test.go
@@ -1,6 +1,11 @@
 package geyserliteabi
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"os"
 	"regexp"
 	"strings"
@@ -67,6 +72,12 @@ func TestNativeHeaderFreezesCallbackABI(t *testing.T) {
 		"GEYSERLITE_ASSIGN_DUPLICATE_HANDLE_OR_CORRELATION -2",
 		"GEYSERLITE_ASSIGN_INVALID_OR_EXPIRED_TIME -3",
 		"GEYSERLITE_ASSIGN_WRONG_CONNECTION_STATE -4",
+		"GEYSERLITE_SUBPROCESS_CONNECTION_OPEN 4",
+		"GEYSERLITE_SUBPROCESS_ACK_POSITIVE 0",
+		"GEYSERLITE_SUBPROCESS_ACK_NEGATIVE 1",
+		"GEYSERLITE_SUBPROCESS_ACK_STATUS_OFFSET 42",
+		"GEYSERLITE_SUBPROCESS_ACK_PACKET_BYTES 75",
+		"GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_PACKET_BYTES 58",
 	} {
 		require.Contains(t, header, definition)
 	}
@@ -77,9 +88,14 @@ func TestSubprocessFramingConstants(t *testing.T) {
 	require.Equal(t, uint8(1), SubprocessAssignment)
 	require.Equal(t, uint8(2), SubprocessAssignmentACK)
 	require.Equal(t, uint8(3), SubprocessVerifiedIngress)
+	require.Equal(t, uint8(4), SubprocessConnectionOpen)
+	require.Equal(t, uint8(0), SubprocessACKPositive)
+	require.Equal(t, uint8(1), SubprocessACKNegative)
 	require.Equal(t, 32, SubprocessIPCKeyBytes)
 	require.Equal(t, 32, SubprocessMACBytes)
 	require.Equal(t, 8192, MaxAuthenticatedPacketBytes)
+	require.Equal(t, 58, SubprocessConnectionOpenPacketBytes)
+	require.Equal(t, 75, SubprocessAssignmentACKPacketBytes)
 
 	raw, err := os.ReadFile("SUBPROCESS_FRAMING.md")
 	require.NoError(t, err)
@@ -88,6 +104,253 @@ func TestSubprocessFramingConstants(t *testing.T) {
 	require.Contains(t, contract, "version=1 || type=1 || generation_u64_be || sequence_u64_be || connection_handle_u64_be || correlation_16 || expires_unix_ms_u64_be || HMAC-SHA256")
 	require.Contains(t, contract, "type=2")
 	require.Contains(t, contract, "type=3")
+	require.Contains(t, contract, "type=4")
+}
+
+func TestSubprocessConnectionOpenRoundTrip(t *testing.T) {
+	key := subprocessTestKey()
+	want := subprocessTestPacket{
+		packetType:       SubprocessConnectionOpen,
+		generation:       0x0102030405060708,
+		sequence:         0x1112131415161718,
+		connectionHandle: 0x2122232425262728,
+	}
+
+	wire := encodeSubprocessTestPacket(t, key, want)
+	require.Len(t, wire, SubprocessConnectionOpenPacketBytes)
+	require.Equal(t,
+		"01040102030405060708111213141516171821222324252627283365040b57686da6d582b14d5cae21a4d52d337afcbddafafa09afb18f1389df",
+		hex.EncodeToString(wire),
+	)
+
+	got, err := decodeSubprocessConnectionOpenTestPacket(key, wire)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestSubprocessAssignmentACKStatusRoundTrip(t *testing.T) {
+	key := subprocessTestKey()
+	tests := []struct {
+		name   string
+		status uint8
+		hex    string
+	}{
+		{
+			name:   "positive",
+			status: SubprocessACKPositive,
+			hex:    "0102010203040506070811121314151617182122232425262728303132333435363738393a3b3c3d3e3f00e34e1ea4f2729bae7994c1077eacba40f62f25fdf85a6bce159dbc999dc01a0a",
+		},
+		{
+			name:   "negative",
+			status: SubprocessACKNegative,
+			hex:    "0102010203040506070811121314151617182122232425262728303132333435363738393a3b3c3d3e3f01225c9e9ec7386c89065bd036f9a427b28df11a36c72f5737c8444ab2eb428d8a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := subprocessTestPacket{
+				packetType:       SubprocessAssignmentACK,
+				generation:       0x0102030405060708,
+				sequence:         0x1112131415161718,
+				connectionHandle: 0x2122232425262728,
+				correlation:      subprocessTestCorrelation(),
+				ackStatus:        tt.status,
+			}
+
+			wire := encodeSubprocessTestPacket(t, key, want)
+			require.Len(t, wire, SubprocessAssignmentACKPacketBytes)
+			require.Equal(t, tt.hex, hex.EncodeToString(wire))
+			got, err := decodeSubprocessAssignmentACKTestPacket(key, wire)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+func TestSubprocessAssignmentACKRejectsMissingOrMalformedStatus(t *testing.T) {
+	key := subprocessTestKey()
+	legacyACKWithoutStatus := mustDecodeHex(t,
+		"0102010203040506070811121314151617182122232425262728303132333435363738393a3b3c3d3e3fc6f55900ddae71ead5dad40dd1d77ca6086a28c74346a790fbc5afc54360b0a2",
+	)
+	_, err := decodeSubprocessAssignmentACKTestPacket(key, legacyACKWithoutStatus)
+	require.ErrorIs(t, err, errSubprocessTestPacketLength)
+
+	malformed := encodeSubprocessTestPacket(t, key, subprocessTestPacket{
+		packetType:       SubprocessAssignmentACK,
+		generation:       1,
+		sequence:         1,
+		connectionHandle: 1,
+		correlation:      subprocessTestCorrelation(),
+		ackStatus:        2,
+	})
+	_, err = decodeSubprocessAssignmentACKTestPacket(key, malformed)
+	require.ErrorIs(t, err, errSubprocessTestACKStatus)
+}
+
+func TestExistingSubprocessPacketWireEncodingRemainsFrozen(t *testing.T) {
+	key := subprocessTestKey()
+	tests := []struct {
+		name   string
+		packet subprocessTestPacket
+		hex    string
+	}{
+		{
+			name: "assignment type 1",
+			packet: subprocessTestPacket{
+				packetType:       SubprocessAssignment,
+				generation:       0x0102030405060708,
+				sequence:         0x1112131415161718,
+				connectionHandle: 0x2122232425262728,
+				correlation:      subprocessTestCorrelation(),
+				expiresUnixMS:    0x4142434445464748,
+			},
+			hex: "0101010203040506070811121314151617182122232425262728303132333435363738393a3b3c3d3e3f4142434445464748af5225f34100d86a7cff80d08d11b2cc06ae9c22c8be08e259a56ee61f1bc525",
+		},
+		{
+			name: "verified ingress type 3",
+			packet: subprocessTestPacket{
+				packetType:       SubprocessVerifiedIngress,
+				generation:       0x0102030405060708,
+				sequence:         0x1112131415161718,
+				connectionHandle: 0x2122232425262728,
+				payload:          mustDecodeHex(t, "08011210303132333435363738393a3b3c3d3e3f"),
+			},
+			hex: "010301020304050607081112131415161718212223242526272808011210303132333435363738393a3b3c3d3e3fe82e9c5cc7512273daf1a6b54537d49a3f59d0cdeef965f3215c7862007232e1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.hex, hex.EncodeToString(encodeSubprocessTestPacket(t, key, tt.packet)))
+		})
+	}
+
+	// Type 2 retains every pre-existing field at its original byte offset. The
+	// new authenticated status byte is appended immediately before the MAC.
+	positiveACK := encodeSubprocessTestPacket(t, key, subprocessTestPacket{
+		packetType:       SubprocessAssignmentACK,
+		generation:       0x0102030405060708,
+		sequence:         0x1112131415161718,
+		connectionHandle: 0x2122232425262728,
+		correlation:      subprocessTestCorrelation(),
+		ackStatus:        SubprocessACKPositive,
+	})
+	require.Equal(t,
+		"0102010203040506070811121314151617182122232425262728303132333435363738393a3b3c3d3e3f",
+		hex.EncodeToString(positiveACK[:SubprocessAssignmentACKStatusOffset]),
+	)
+}
+
+var (
+	errSubprocessTestPacketLength = errors.New("invalid subprocess packet length")
+	errSubprocessTestACKStatus    = errors.New("invalid subprocess ACK status")
+)
+
+type subprocessTestPacket struct {
+	packetType       uint8
+	generation       uint64
+	sequence         uint64
+	connectionHandle uint64
+	correlation      [CorrelationBytes]byte
+	expiresUnixMS    uint64
+	ackStatus        uint8
+	payload          []byte
+}
+
+func encodeSubprocessTestPacket(t *testing.T, key []byte, packet subprocessTestPacket) []byte {
+	t.Helper()
+	var authenticated []byte
+	switch packet.packetType {
+	case SubprocessAssignment:
+		authenticated = make([]byte, SubprocessAssignmentMACOffset)
+		copy(authenticated[SubprocessCorrelationOffset:], packet.correlation[:])
+		binary.BigEndian.PutUint64(authenticated[SubprocessAssignmentExpiresOffset:], packet.expiresUnixMS)
+	case SubprocessAssignmentACK:
+		authenticated = make([]byte, SubprocessAssignmentACKMACOffset)
+		copy(authenticated[SubprocessCorrelationOffset:], packet.correlation[:])
+		authenticated[SubprocessAssignmentACKStatusOffset] = packet.ackStatus
+	case SubprocessVerifiedIngress:
+		authenticated = make([]byte, SubprocessVerifiedIngressPayloadOffset+len(packet.payload))
+		copy(authenticated[SubprocessVerifiedIngressPayloadOffset:], packet.payload)
+	case SubprocessConnectionOpen:
+		authenticated = make([]byte, SubprocessConnectionOpenMACOffset)
+	default:
+		t.Fatalf("unsupported test packet type %d", packet.packetType)
+	}
+	authenticated[SubprocessVersionOffset] = SubprocessFrameVersion
+	authenticated[SubprocessTypeOffset] = packet.packetType
+	binary.BigEndian.PutUint64(authenticated[SubprocessGenerationOffset:], packet.generation)
+	binary.BigEndian.PutUint64(authenticated[SubprocessSequenceOffset:], packet.sequence)
+	binary.BigEndian.PutUint64(authenticated[SubprocessConnectionHandleOffset:], packet.connectionHandle)
+	mac := hmac.New(sha256.New, key)
+	_, err := mac.Write(authenticated)
+	require.NoError(t, err)
+	return append(authenticated, mac.Sum(nil)...)
+}
+
+func decodeSubprocessConnectionOpenTestPacket(key, wire []byte) (subprocessTestPacket, error) {
+	if len(wire) != SubprocessConnectionOpenPacketBytes {
+		return subprocessTestPacket{}, errSubprocessTestPacketLength
+	}
+	if !validSubprocessTestMAC(key, wire, SubprocessConnectionOpenMACOffset) {
+		return subprocessTestPacket{}, errors.New("invalid subprocess packet MAC")
+	}
+	return decodeSubprocessTestPrefix(wire, SubprocessConnectionOpen), nil
+}
+
+func decodeSubprocessAssignmentACKTestPacket(key, wire []byte) (subprocessTestPacket, error) {
+	if len(wire) != SubprocessAssignmentACKPacketBytes {
+		return subprocessTestPacket{}, errSubprocessTestPacketLength
+	}
+	if !validSubprocessTestMAC(key, wire, SubprocessAssignmentACKMACOffset) {
+		return subprocessTestPacket{}, errors.New("invalid subprocess packet MAC")
+	}
+	status := wire[SubprocessAssignmentACKStatusOffset]
+	if status != SubprocessACKPositive && status != SubprocessACKNegative {
+		return subprocessTestPacket{}, errSubprocessTestACKStatus
+	}
+	packet := decodeSubprocessTestPrefix(wire, SubprocessAssignmentACK)
+	copy(packet.correlation[:], wire[SubprocessCorrelationOffset:SubprocessAssignmentACKStatusOffset])
+	packet.ackStatus = status
+	return packet, nil
+}
+
+func decodeSubprocessTestPrefix(wire []byte, packetType uint8) subprocessTestPacket {
+	if wire[SubprocessVersionOffset] != SubprocessFrameVersion || wire[SubprocessTypeOffset] != packetType {
+		return subprocessTestPacket{}
+	}
+	return subprocessTestPacket{
+		packetType:       packetType,
+		generation:       binary.BigEndian.Uint64(wire[SubprocessGenerationOffset:]),
+		sequence:         binary.BigEndian.Uint64(wire[SubprocessSequenceOffset:]),
+		connectionHandle: binary.BigEndian.Uint64(wire[SubprocessConnectionHandleOffset:]),
+	}
+}
+
+func validSubprocessTestMAC(key, wire []byte, macOffset int) bool {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(wire[:macOffset])
+	return hmac.Equal(wire[macOffset:], mac.Sum(nil))
+}
+
+func subprocessTestKey() []byte {
+	key := make([]byte, SubprocessIPCKeyBytes)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	return key
+}
+
+func subprocessTestCorrelation() [CorrelationBytes]byte {
+	var correlation [CorrelationBytes]byte
+	copy(correlation[:], "0123456789:;<=>?")
+	return correlation
+}
+
+func mustDecodeHex(t *testing.T, value string) []byte {
+	t.Helper()
+	decoded, err := hex.DecodeString(value)
+	require.NoError(t, err)
+	return decoded
 }
 
 func stripFullMatches(matches [][]string) [][]string {

--- a/geyserliteabi/geyserlite_verified_ingress_v1.h
+++ b/geyserliteabi/geyserlite_verified_ingress_v1.h
@@ -23,11 +23,12 @@ typedef struct __graal_isolatethread_t graal_isolatethread_t;
 #define GEYSERLITE_ASSIGN_WRONG_CONNECTION_STATE -4
 
 /*
- * Authenticated subprocess framing v1. All integers are unsigned big-endian,
- * and every packet ends in a 32-byte HMAC-SHA256 over all preceding bytes.
- * Connection-open is type 4 and exactly 58 bytes. Assignment ACK is type 2
- * and exactly 75 bytes; its authenticated status byte is 0 (positive) or 1
- * (negative). Any missing or other status is fail-closed.
+ * Authenticated subprocess framing v1. The bootstrap is exactly 41 bytes with
+ * a 32-byte key; authenticated packets are at most 8192 bytes. All integers
+ * are unsigned big-endian, and every packet ends in a 32-byte HMAC-SHA256 over
+ * all preceding bytes. Connection-open is type 4 and exactly 58 bytes.
+ * Assignment ACK is type 2 and exactly 75 bytes; its authenticated status byte
+ * is 0 (positive) or 1 (negative). Any missing or other status is fail-closed.
  */
 #define GEYSERLITE_SUBPROCESS_FRAME_VERSION 1
 #define GEYSERLITE_SUBPROCESS_ASSIGNMENT 1
@@ -38,15 +39,30 @@ typedef struct __graal_isolatethread_t graal_isolatethread_t;
 #define GEYSERLITE_SUBPROCESS_ACK_POSITIVE 0
 #define GEYSERLITE_SUBPROCESS_ACK_NEGATIVE 1
 
+#define GEYSERLITE_SUBPROCESS_BOOTSTRAP_PACKET_BYTES 41
+#define GEYSERLITE_SUBPROCESS_IPC_KEY_BYTES 32
+#define GEYSERLITE_SUBPROCESS_MAC_BYTES 32
+#define GEYSERLITE_SUBPROCESS_MAX_PACKET_BYTES 8192
+
 #define GEYSERLITE_SUBPROCESS_VERSION_OFFSET 0
 #define GEYSERLITE_SUBPROCESS_TYPE_OFFSET 1
 #define GEYSERLITE_SUBPROCESS_GENERATION_OFFSET 2
 #define GEYSERLITE_SUBPROCESS_SEQUENCE_OFFSET 10
 #define GEYSERLITE_SUBPROCESS_CONNECTION_HANDLE_OFFSET 18
 #define GEYSERLITE_SUBPROCESS_CORRELATION_OFFSET 26
+
+#define GEYSERLITE_SUBPROCESS_ASSIGNMENT_EXPIRES_OFFSET 42
+#define GEYSERLITE_SUBPROCESS_ASSIGNMENT_MAC_OFFSET 50
+#define GEYSERLITE_SUBPROCESS_ASSIGNMENT_PACKET_BYTES 82
+
 #define GEYSERLITE_SUBPROCESS_ACK_STATUS_OFFSET 42
 #define GEYSERLITE_SUBPROCESS_ACK_MAC_OFFSET 43
 #define GEYSERLITE_SUBPROCESS_ACK_PACKET_BYTES 75
+
+#define GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_PAYLOAD_OFFSET 26
+#define GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_MIN_PACKET_BYTES 59
+#define GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS_MAX_PACKET_BYTES 4154
+
 #define GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_MAC_OFFSET 26
 #define GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_PACKET_BYTES 58
 

--- a/geyserliteabi/geyserlite_verified_ingress_v1.h
+++ b/geyserliteabi/geyserlite_verified_ingress_v1.h
@@ -22,6 +22,34 @@ typedef struct __graal_isolatethread_t graal_isolatethread_t;
 #define GEYSERLITE_ASSIGN_INVALID_OR_EXPIRED_TIME -3
 #define GEYSERLITE_ASSIGN_WRONG_CONNECTION_STATE -4
 
+/*
+ * Authenticated subprocess framing v1. All integers are unsigned big-endian,
+ * and every packet ends in a 32-byte HMAC-SHA256 over all preceding bytes.
+ * Connection-open is type 4 and exactly 58 bytes. Assignment ACK is type 2
+ * and exactly 75 bytes; its authenticated status byte is 0 (positive) or 1
+ * (negative). Any missing or other status is fail-closed.
+ */
+#define GEYSERLITE_SUBPROCESS_FRAME_VERSION 1
+#define GEYSERLITE_SUBPROCESS_ASSIGNMENT 1
+#define GEYSERLITE_SUBPROCESS_ASSIGNMENT_ACK 2
+#define GEYSERLITE_SUBPROCESS_VERIFIED_INGRESS 3
+#define GEYSERLITE_SUBPROCESS_CONNECTION_OPEN 4
+
+#define GEYSERLITE_SUBPROCESS_ACK_POSITIVE 0
+#define GEYSERLITE_SUBPROCESS_ACK_NEGATIVE 1
+
+#define GEYSERLITE_SUBPROCESS_VERSION_OFFSET 0
+#define GEYSERLITE_SUBPROCESS_TYPE_OFFSET 1
+#define GEYSERLITE_SUBPROCESS_GENERATION_OFFSET 2
+#define GEYSERLITE_SUBPROCESS_SEQUENCE_OFFSET 10
+#define GEYSERLITE_SUBPROCESS_CONNECTION_HANDLE_OFFSET 18
+#define GEYSERLITE_SUBPROCESS_CORRELATION_OFFSET 26
+#define GEYSERLITE_SUBPROCESS_ACK_STATUS_OFFSET 42
+#define GEYSERLITE_SUBPROCESS_ACK_MAC_OFFSET 43
+#define GEYSERLITE_SUBPROCESS_ACK_PACKET_BYTES 75
+#define GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_MAC_OFFSET 26
+#define GEYSERLITE_SUBPROCESS_CONNECTION_OPEN_PACKET_BYTES 58
+
 typedef void (*gate_verified_ingress_v1_cb)(
     const uint8_t correlation[16], const uint8_t *frame,
     uint32_t frame_len, uint64_t expires_unix_ms);


### PR DESCRIPTION
## Intent

Complete the already-approved Bedrock Option A GeyserLite VerifiedIngressV1 subprocess ABI without changing or renumbering packet types 1, 2, or 3. Add authenticated type 4 for the child-minted connection-open handle publication, with generation and sequence binding and a fixed byte layout; Gate subsequently binds its 16-byte correlation through the unchanged type-1 assignment. Extend type-2 ACK by appending one authenticated status byte after the existing correlation, where 0 is positive and 1 is negative, preserving every existing field offset and rejecting missing or unknown status values. Freeze exact sizes, offsets, HMAC vectors, round trips, and legacy type-1/type-3 wire encodings in tests, and document the contract in SUBPROCESS_FRAMING.md and the C header. Remain source/interface-only: no OAuth, credentials, secrets, production/customer endpoints, releases, deployments, Moxy PR 511, or kunchenguid repositories.

## What Changed

- Added authenticated type-4 connection-open framing with fixed layout and generation/sequence-bound handle publication.
- Extended type-2 ACKs with an authenticated positive/negative status byte while preserving existing field offsets and rejecting invalid statuses.
- Documented the frozen ABI in Markdown and the C header, with regression tests for constants, sizes, offsets, HMAC vectors, round trips, and legacy encodings.

## Risk Assessment

✅ Low: The source-only ABI changes are bounded, preserve packet types and legacy wire vectors, and now include the requested C-header constants plus Go/C parity and boundary regression checks; no concrete source defect was found.

## Testing

The source-only ABI tests exercised exact sizes, offsets, HMAC vectors, type-4 and ACK round trips, malformed-status rejection, frozen type-1/type-3 encodings, bounds, and Go/C header parity; all targeted checks completed successfully. No worktree artifacts were created.

<details>
<summary>Evidence: Focused ABI protocol test transcript</summary>

```text
=== RUN   TestNativeHeaderFreezesCallbackABI
--- PASS: TestNativeHeaderFreezesCallbackABI (0.00s)
=== RUN   TestSubprocessFramingConstants
--- PASS: TestSubprocessFramingConstants (0.00s)
=== RUN   TestSubprocessConnectionOpenRoundTrip
--- PASS: TestSubprocessConnectionOpenRoundTrip (0.00s)
=== RUN   TestSubprocessAssignmentACKStatusRoundTrip
=== RUN   TestSubprocessAssignmentACKStatusRoundTrip/positive
=== RUN   TestSubprocessAssignmentACKStatusRoundTrip/negative
--- PASS: TestSubprocessAssignmentACKStatusRoundTrip (0.00s)
    --- PASS: TestSubprocessAssignmentACKStatusRoundTrip/positive (0.00s)
    --- PASS: TestSubprocessAssignmentACKStatusRoundTrip/negative (0.00s)
=== RUN   TestSubprocessAssignmentACKRejectsMissingOrMalformedStatus
--- PASS: TestSubprocessAssignmentACKRejectsMissingOrMalformedStatus (0.00s)
=== RUN   TestExistingSubprocessPacketWireEncodingRemainsFrozen
=== RUN   TestExistingSubprocessPacketWireEncodingRemainsFrozen/assignment_type_1
=== RUN   TestExistingSubprocessPacketWireEncodingRemainsFrozen/verified_ingress_type_3
--- PASS: TestExistingSubprocessPacketWireEncodingRemainsFrozen (0.00s)
    --- PASS: TestExistingSubprocessPacketWireEncodingRemainsFrozen/assignment_type_1 (0.00s)
    --- PASS: TestExistingSubprocessPacketWireEncodingRemainsFrozen/verified_ingress_type_3 (0.00s)
=== RUN   TestSubprocessVerifiedIngressPacketBounds
--- PASS: TestSubprocessVerifiedIngressPacketBounds (0.00s)
PASS
ok  	go.minekube.com/connect/geyserliteabi	0.180s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `geyserliteabi/geyserlite_verified_ingress_v1.h:41` - The required criterion says: “document the contract in SUBPROCESS_FRAMING.md and the C header.” The C header exposes only common, type-2, and type-4 layout values; it omits type-1 offsets/size, type-3 bounds, and bootstrap/key/MAC limits, so C consumers cannot validate the full frozen contract.
- 🚨 `geyserliteabi/abi_test.go:86` - The required criterion says: “Freeze exact sizes, offsets, HMAC vectors, round trips, and legacy type-1/type-3 wire encodings in tests.” `SubprocessAssignmentPacketBytes` and the type-3 59–4154 bounds are never asserted or used, and C-header constants are not cross-checked, allowing contract drift without a failing test.

🔧 Fix: Documented ABI constants and added regression-proof parity tests
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./geyserliteabi -run 'Test(NativeHeaderFreezesCallbackABI|SubprocessFramingConstants|SubprocessConnectionOpenRoundTrip|SubprocessAssignmentACKStatusRoundTrip|SubprocessAssignmentACKRejectsMissingOrMalformedStatus|ExistingSubprocessPacketWireEncodingRemainsFrozen|SubprocessVerifiedIngressPacketBounds)$' -count=1 -v`
- `go test ./geyserliteabi -count=1`
- <code>`cc -std=c11 -fsyntax-only -Igeyserliteabi -x c -` with ABI static assertions</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
