### PR TITLE
fix(docs): normalize generated Markdown routes

### DIFF
--- a/.web/docs/public/_headers
+++ b/.web/docs/public/_headers
@@ -5,14 +5,10 @@
   Link: </llms.txt>; rel="llms-txt", </llms-full.txt>; rel="llms-full-txt"
   X-Llms-Txt: /llms.txt
 
-# VitePress clean URLs require an explicit HTML charset header.
+# Cloudflare derives HTML MIME types from the uploaded .html assets. Keep
+# these rules exact: wildcard HTML rules also match generated .md routes and
+# Cloudflare joins duplicate Content-Type values instead of overriding them.
 /
-  Content-Type: text/html; charset=utf-8
-
-/guide/*
-  Content-Type: text/html; charset=utf-8
-
-/changelog/*
   Content-Type: text/html; charset=utf-8
 
 /blog/

--- a/.web/scripts/workers-migration.test.mjs
+++ b/.web/scripts/workers-migration.test.mjs
@@ -6,11 +6,10 @@ import { normalizePagesResponse } from '../worker-response.mjs';
 
 const redirectPaths = [
   '/*.html',
+  '/guide/*',
+  '/changelog/*',
   '/discord',
   '/discord/',
-  '/guide/changelog',
-  '/guide/changelog/',
-  '/guide/changelog.html',
 ];
 
 const readConfig = async (name) =>
@@ -92,8 +91,6 @@ test('production and canary Workers preserve the Connect Pages contract', async 
 
   for (const path of [
     '/',
-    '/guide/*',
-    '/changelog/*',
     '/blog/',
     '/blog/gate-api',
     '/blog/gate-lite',
@@ -108,6 +105,14 @@ test('production and canary Workers preserve the Connect Pages contract', async 
       hasHeaderRule(headers, path, 'Content-Type', 'text/html; charset=utf-8'),
       true,
       `missing HTML charset header rule for ${path}`
+    );
+  }
+
+  for (const path of ['/guide/*', '/changelog/*']) {
+    assert.equal(
+      hasHeaderRule(headers, path, 'Content-Type'),
+      false,
+      `${path} must not overlap generated Markdown route content types`
     );
   }
 
@@ -127,6 +132,17 @@ test('production and canary Workers preserve the Connect Pages contract', async 
       `missing ${name} header rule for ${path}`
     );
   }
+
+  assert.equal(
+    hasHeaderRule(
+      headers,
+      '/*.md',
+      'Content-Type',
+      'text/markdown; charset=utf-8'
+    ),
+    true,
+    'Markdown routes must set one exact Markdown content type'
+  );
 });
 
 test('the Worker preserves Pages response headers and redirect metadata', async () => {
@@ -283,6 +299,40 @@ test('the Worker recreates Pages canonical HTML redirects', async () => {
     assert.equal(head.headers.get('location'), destination);
     assert.equal(head.headers.get('content-length'), null);
     assert.equal(await head.text(), '');
+  }
+});
+
+test('the Worker normalizes HTML and Markdown below clean-URL trees', async () => {
+  const assets = {
+    fetch(request) {
+      const pathname = new URL(request.url).pathname;
+      if (pathname.endsWith('.md')) {
+        return new Response('# Bedrock', {
+          headers: {
+            'content-type':
+              'text/markdown; charset=utf-8, text/html; charset=utf-8',
+          },
+        });
+      }
+
+      return new Response('<!doctype html>', {
+        headers: { 'content-type': 'text/html' },
+      });
+    },
+  };
+
+  for (const [path, type] of [
+    ['/guide/bedrock', 'text/html; charset=utf-8'],
+    ['/changelog/', 'text/html; charset=utf-8'],
+    ['/guide/bedrock.md', 'text/markdown; charset=utf-8'],
+  ]) {
+    const response = await worker.fetch(
+      new Request(`https://connect.minekube.com${path}`),
+      { ASSETS: assets }
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), type);
   }
 });
 

--- a/.web/worker.mjs
+++ b/.web/worker.mjs
@@ -87,6 +87,18 @@ const createFixedLengthBody = (response) => {
   return readable;
 };
 
+const normalizeMarkdownResponse = (response) => {
+  const normalized = normalizePagesResponse(response);
+  const headers = new Headers(normalized.headers);
+  headers.set('content-type', 'text/markdown; charset=utf-8');
+
+  return new Response(normalized.body, {
+    status: normalized.status,
+    statusText: normalized.statusText,
+    headers,
+  });
+};
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -102,6 +114,10 @@ export default {
 
     const response = await env.ASSETS.fetch(request);
     if (response.status !== 404) {
+      if (url.pathname.endsWith('.md')) {
+        return normalizeMarkdownResponse(response);
+      }
+
       return normalizePagesResponse(response);
     }
 

--- a/.web/wrangler.canary.jsonc
+++ b/.web/wrangler.canary.jsonc
@@ -15,11 +15,10 @@
     "binding": "ASSETS",
     "run_worker_first": [
       "/*.html",
+      "/guide/*",
+      "/changelog/*",
       "/discord",
-      "/discord/",
-      "/guide/changelog",
-      "/guide/changelog/",
-      "/guide/changelog.html"
+      "/discord/"
     ]
   }
 }

--- a/.web/wrangler.jsonc
+++ b/.web/wrangler.jsonc
@@ -15,11 +15,10 @@
     "binding": "ASSETS",
     "run_worker_first": [
       "/*.html",
+      "/guide/*",
+      "/changelog/*",
       "/discord",
-      "/discord/",
-      "/guide/changelog",
-      "/guide/changelog/",
-      "/guide/changelog.html"
+      "/discord/"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- stop broad HTML `_headers` rules from appending `text/html` to generated Markdown responses
- run only the clean guide and changelog URL trees through the existing response normalizer
- set one exact Markdown MIME type and preserve UTF-8 HTML responses
- remove route entries made redundant by the broader worker-first trees

## Verification
- `yarn test:worker` (8/8)
- `yarn check:docs`
- `yarn build`
- Canary `c5012cc6-8591-4345-9d01-d754ceb0fd06`
- enumerated 24 generated Markdown and 39 clean HTML routes across the public canary

Follow-up to #145 after canary validation exposed Cloudflare `_headers` overlap.