### PR TITLE
docs: clarify reported connector compatibility limits

### DIFF
--- a/.web/docs/guide/compatibility.md
+++ b/.web/docs/guide/compatibility.md
@@ -25,6 +25,7 @@ the combinations that most often need extra care.
 | Velocity snapshots | Medium | Ask for the exact Velocity build and Connect plugin version. Reproduce on a stable Velocity build if packet or login behavior changed. |
 | FastLogin, AuthMe, NLogin, and similar login plugins | Medium to high | Ask whether the server is online-mode, offline-mode, or mixed. Confirm whether the player joined through Connect, TCPShield, direct proxy, or direct backend. Do not treat a Connect-managed Bedrock report as a reason to enable direct Gate Bedrock. See [Login and Auth Plugins](/guide/login-plugins) for the rule that decides whether a login plugin conflicts with Connect. |
 | LibreLogin with premium autologin enabled | Version-dependent | Use Connect v0.13.1 or newer and keep premium autologin enabled. See [Login and Auth Plugins](/guide/login-plugins#librelogin-with-premium-autologin) for the default skin handling and optional profile settings. |
+| PacketEvents-based Velocity plugins (including Sonar and some nLogin builds) | Product incompatibility | A tunneled player can reach post-login and then disconnect because PacketEvents expects Velocity's ordinary socket-channel state while Connect supplies a local tunnel channel. Removing only the auth plugin is not a durable fix when it depends on PacketEvents. Compare a direct Velocity join, collect the PacketEvents/plugin versions and exception, and follow [connect-java#141](https://github.com/minekube/connect-java/issues/141). |
 | Gate Lite with an online-mode backend | High | AuthSession/passthrough for Lite backend routes is not available today. Do not suggest `-Dmojang.sessionserver=` or a Gate Lite config change as a working fix. Recommend standard Gate with Connect enabled or the Connect Java Plugin on the online-mode proxy/server. |
 | MultiProxySync and profile/skin sync plugins | Medium | Check whether UUID/profile data is expected from the proxy, backend, or plugin. Compare behavior between the direct proxy path and the Connect path. |
 | TCPShield in front of Java while Connect handles Bedrock | Medium | Treat as two ingress paths. Ask which hostname the player used and whether forwarding is configured consistently on both paths. |
@@ -40,12 +41,28 @@ the combinations that most often need extra care.
 | Fabric servers with FabricProxy-Lite | Medium | Verify the proxy forwarding mod expected by the backend is installed, enabled, and configured with the same forwarding secret as the proxy. |
 | Fabric servers with CrossStitch | Medium | CrossStitch is required when the Fabric backend needs Velocity modern forwarding support that FabricProxy-Lite alone does not provide. It is recommended when users report login/profile mismatch with Velocity-style forwarding. Verify by checking the backend log for the forwarding mod loading and by confirming direct Velocity-to-backend login works before adding Connect. |
 | Polymer and server-side mod stacks | Medium | Usually compatible when the server remains vanilla-protocol compatible. Ask whether the issue also occurs without Connect and collect the mod list when resource-pack, profile, or login behavior differs. |
-| NeoForge 1.21.x / Proxy-Compatible-Forge through Connect | Product investigation | Classify as a Connect compatibility investigation, not generic local Gate misconfiguration. Preserve the join address, Connect plugin version, proxy type/version, NeoForge version, Proxy-Compatible-Forge version, exact kick text, and logs from the status/login/configuration phases. Track product regression coverage in [connect#111](https://github.com/minekube/connect/issues/111). |
+| NeoForge 1.21.x / Proxy-Compatible-Forge through Connect | Product investigation | Gate v0.69.1 fixed the open-bundle transition defect that was proven, and the Connect edge consumes that fix with regression coverage. A complete end-to-end NeoForge path has not yet been proven, and later failures may have a different cause. Preserve the join address, Connect plugin version, proxy type/version, NeoForge version, Proxy-Compatible-Forge version, exact kick text, and status/login/configuration-phase logs, then follow [connect#111](https://github.com/minekube/connect/issues/111). |
 | Modpacks requiring custom client handshakes | Medium to high | Confirm whether the proxy and backend both support the required handshake. |
 
-Use a product bug when a NeoForge or Forge-compatible path works through the same proxy without Connect but fails only
-through Connect. The report should focus on whether Connect preserves the status, login, plugin-message, and
-configuration-phase metadata the backend forwarding mod expects.
+Use a product bug when a NeoForge or Forge-compatible path works through the same proxy without Connect but still fails
+only through the current Connect edge. The report should focus on whether Connect preserves the status, login,
+plugin-message, and configuration-phase metadata the backend forwarding mod expects.
+
+## Voice Chat
+
+Connect does not currently tunnel the separate UDP transport used by proximity-voice plugins such as Simple Voice
+Chat. Minecraft can still join through the Connect hostname, but voice packets cannot use that hostname because the
+Connect edge has no UDP voice listener or route to the backend yet. This limitation is tracked in
+[connect#159](https://github.com/minekube/connect/issues/159).
+
+Server owners can use one of these paths today:
+
+- expose the voice plugin's UDP port (Simple Voice Chat defaults to `24454`) on the backend and configure its
+  `voice_host` to that public address; Minecraft traffic can continue through Connect
+- use a voice system that does not require a direct game UDP path, such as a browser-based voice plugin
+
+Installing Simple Voice Chat beside the Connect plugin does not create a tunnel automatically. The SVC client mod is
+still required, and opening local UDP `19132` does not help: that port is for Bedrock Minecraft traffic, not voice.
 
 ## Bedrock and Account Linking
 

--- a/.web/scripts/check-docs.mjs
+++ b/.web/scripts/check-docs.mjs
@@ -108,7 +108,10 @@ assertAll('docs/guide/compatibility.md', [
   'CrossStitch',
   'Polymer',
   'NeoForge 1.21.x / Proxy-Compatible-Forge through Connect',
-  'Connect compatibility investigation',
+  'Gate v0.69.1 fixed the open-bundle transition',
+  'connect-java/issues/141',
+  'Connect does not currently tunnel the separate UDP transport',
+  'connect/issues/159',
 ])
 
 assertAll('docs/guide/login-plugins.md', [


### PR DESCRIPTION
Documents the current PacketEvents limitation, proximity-voice UDP topology, and the precisely proven scope of the NeoForge open-bundle fix without claiming unverified end-to-end support.

Verified: yarn check:docs; yarn build