### PR TITLE
fix(ws): prevent endpoint watch context race

### DIFF
--- a/ws/server.go
+++ b/ws/server.go
@@ -78,28 +78,26 @@ func (o ServerOptions) EndpointHandler(ln connect.EndpointListener) http.Handler
 		}
 
 		// Prepare endpoint watch
-		ctx, cancel := context.WithCancel(ctx)
+		connectionCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
+		requestCtx := withRequest(connectionCtx, r)
 		ew := &util.EndpointWatch{
 			ProposeFn: func(ctx context.Context, session *connect.Session) error {
 				return wspb.Write(ctx, ws, &connect.WatchResponse{Session: session})
 			},
 			Receive: func() (*connect.WatchRequest, error) {
 				req := new(connect.WatchRequest)
-				return req, wspb.Read(ctx, ws, req)
+				return req, wspb.Read(connectionCtx, ws, req)
 			},
 			RejectionsChan: make(chan *connect.SessionRejection),
 		}
 
 		// Receive session rejections from endpoint
-		go func() { ew.StartReceiveRejections(ctx); cancel() }()
-		go pingLoop(ctx, pingInterval, ws)
-
-		// Add http request to ctx
-		ctx = withRequest(ctx, r)
+		go func() { ew.StartReceiveRejections(connectionCtx); cancel() }()
+		go pingLoop(connectionCtx, pingInterval, ws)
 
 		// Start blocking watch callback
-		if err = ln.AcceptEndpoint(ctx, ew); err != nil {
+		if err = ln.AcceptEndpoint(requestCtx, ew); err != nil {
 			// Specify meaningful close error
 			_ = ws.Close(websocket.StatusProtocolError, fmt.Sprintf(
 				"did not accept endpoint: %v", err))

--- a/ws/server_test.go
+++ b/ws/server_test.go
@@ -1,0 +1,70 @@
+package ws
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"go.minekube.com/connect"
+	"go.minekube.com/connect/internal/wspb"
+)
+
+type endpointListenerFunc func(context.Context, connect.EndpointWatch) error
+
+func (f endpointListenerFunc) AcceptEndpoint(ctx context.Context, watch connect.EndpointWatch) error {
+	return f(ctx, watch)
+}
+
+// TestEndpointHandlerSeparatesConnectionAndRequestContexts exercises the
+// concurrent rejection reader while the handler attaches the HTTP request to
+// the listener context. Run it with -race: the reader must never observe a
+// reassigned context interface.
+func TestEndpointHandlerSeparatesConnectionAndRequestContexts(t *testing.T) {
+	var receivedRequest atomic.Bool
+	rejections := make(chan *connect.SessionRejection, 1)
+	listener := endpointListenerFunc(func(ctx context.Context, watch connect.EndpointWatch) error {
+		receivedRequest.Store(RequestFromContext(ctx) != nil)
+		select {
+		case rejection, ok := <-watch.Rejections():
+			if ok {
+				rejections <- rejection
+			}
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	server := httptest.NewServer(ServerOptions{}.EndpointHandler(listener))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial endpoint watch: %v", err)
+	}
+	defer ws.Close(websocket.StatusNormalClosure, "test complete")
+
+	want := &connect.SessionRejection{Id: "race-regression"}
+	if err := wspb.Write(ctx, ws, &connect.WatchRequest{SessionRejection: want}); err != nil {
+		t.Fatalf("write rejection: %v", err)
+	}
+
+	select {
+	case got := <-rejections:
+		if got.GetId() != want.GetId() {
+			t.Fatalf("received rejection ID = %q, want %q", got.GetId(), want.GetId())
+		}
+	case <-ctx.Done():
+		t.Fatalf("did not receive rejection: %v", ctx.Err())
+	}
+	if !receivedRequest.Load() {
+		t.Fatal("endpoint listener did not receive the HTTP request context")
+	}
+}


### PR DESCRIPTION
## Summary
- isolate the immutable WebSocket/rejection context from the request-enriched listener context
- prevent a concurrent closure from reading a reassigned `context.Context` interface
- cover rejection delivery and request context propagation with a WebSocket regression test

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./ws -run TestEndpointHandlerSeparatesConnectionAndRequestContexts -count=100`

Local `make lint` could not start because the downloaded golangci-lint cannot decode the host Go 1.27 export-data version; repository CI uses its configured Go toolchain.