### PR TITLE
fix(bedrock): allow endpoint-scoped v2 principals

### DIFF
--- a/bedrockprincipal/WIRE_FOLLOWUP.md
+++ b/bedrockprincipal/WIRE_FOLLOWUP.md
@@ -20,3 +20,12 @@ dependency, exposing proposal accessors/shared codecs, and implementing
 consumer transport behavior remain separate downstream work. No generated
 dependency version, release, endpoint, credential, or production behavior is
 invented by this branch.
+
+## Endpoint-scoped organization binding
+
+`organization_id` remains a required signed field, but its value may be empty
+for an endpoint that has no dashboard organization. Empty does not mean
+unbound: verifiers require an exact match with the trusted proposal context,
+and continue to require non-empty endpoint and session bindings, a valid
+signature, and replay protection. Consumers must therefore pass the actual
+endpoint-scoped empty value rather than substituting an organization ID.

--- a/bedrockprincipal/internal/vectorgen/generator.go
+++ b/bedrockprincipal/internal/vectorgen/generator.go
@@ -60,6 +60,8 @@ type definition struct {
 
 func definitions() map[string]definition {
 	validUnlinked := payload(1)
+	validOrgless := payload(7)
+	validOrgless["organization_id"] = ""
 	validLinked := payload(2)
 	validLinked["subject_kind"] = "bedrock_linked_java"
 	validLinked["verification_method"] = "minecraft_full_jwks+client_jwt+ecdh_v1"
@@ -78,12 +80,13 @@ func definitions() map[string]definition {
 	lifetime["exp"] = fixedNow + 31
 	tampered := payload(6)
 	return map[string]definition{
-		"valid-unlinked":           {payload: validUnlinked},
-		"valid-linked":             {payload: validLinked},
-		"malformed-jti-tail-bits":  {payload: malformedJTI},
-		"policy-revision-mismatch": {payload: policy},
-		"lifetime-thirty-one":      {payload: lifetime},
-		"tampered-signature":       {payload: tampered, tamperSignature: true},
+		"valid-unlinked":                {payload: validUnlinked},
+		"valid-orgless-endpoint-scoped": {payload: validOrgless},
+		"valid-linked":                  {payload: validLinked},
+		"malformed-jti-tail-bits":       {payload: malformedJTI},
+		"policy-revision-mismatch":      {payload: policy},
+		"lifetime-thirty-one":           {payload: lifetime},
+		"tampered-signature":            {payload: tampered, tamperSignature: true},
 	}
 }
 

--- a/bedrockprincipal/schema/v2.schema.json
+++ b/bedrockprincipal/schema/v2.schema.json
@@ -34,7 +34,7 @@
     },
     "bedrock_display_name": {"type": "string", "minLength": 1, "maxLength": 64},
     "endpoint_id": {"type": "string", "minLength": 1, "maxLength": 128},
-    "organization_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "organization_id": {"type": "string", "maxLength": 128},
     "connect_session_id": {"type": "string", "minLength": 1, "maxLength": 128},
     "connect_session_nonce": {"type": "string", "pattern": "^[A-Za-z0-9_-]{22}$", "minLength": 22, "maxLength": 22},
     "policy_revision": {"type": "integer", "minimum": 1, "maximum": 9223372036854775807},

--- a/bedrockprincipal/testdata/v2/connect-sdk-candidate.json
+++ b/bedrockprincipal/testdata/v2/connect-sdk-candidate.json
@@ -6,8 +6,8 @@
   "tag": null,
   "go_module": "go.minekube.com/connect",
   "corpus_tree": null,
-  "corpus_digest_sha256": "4f2a442ee71bfd35af2ef1f3944489d17551aa77fed2c08220f2aa77032b6196",
-  "schema_sha256": "648677745c5babd03e0e59c1ff5a98cbb0e3a45ab8311632731ee73dd32a807c",
+  "corpus_digest_sha256": "83d3cd045a62e09e331aecece0f7977b06ca5a577f4ff0345be10cd4736a7b07",
+  "schema_sha256": "e8f81b8f22cdffed3ebf1c9cc5b2b3a8c43a0102d93f954d9ad2956fc36168a7",
   "metadata_schema_sha256": "eb92504aee4943144e7d25a5a7dc4fea63429cb848f5cbb6c14fc63254bd1589",
   "artifact_sha256": null
 }

--- a/bedrockprincipal/testdata/v2/core-vectors.json
+++ b/bedrockprincipal/testdata/v2/core-vectors.json
@@ -29,6 +29,35 @@
     }
   },
   {
+    "name": "valid-orgless-endpoint-scoped",
+    "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzAsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQndjSEJ3Y0hCd2NIQndjSEJ3Y0hCdyIsIm5iZiI6MTc4NTQ5MjAwMCwib3JnYW5pemF0aW9uX2lkIjoiIiwicG9saWN5X3JldmlzaW9uIjo3LCJzb3VyY2VfcHJvdG9jb2wiOiJiZWRyb2NrIiwic291cmNlX3Byb3RvY29sX3ZlcnNpb24iOjc3Niwic3ViamVjdF9raW5kIjoiYmVkcm9ja194dWlkIiwidHJ1c3RfZG9tYWluIjoidXJuOm1pbmVrdWJlOmNvbm5lY3Q6dGVzdDpjb3JwdXMtdjIiLCJ2ZXJpZmljYXRpb25fbWV0aG9kIjoibWluZWNyYWZ0X2xlZ2FjeV9jaGFpbitjbGllbnRfand0K2VjZGhfdjEiLCJ2ZXJzaW9uIjoyfQ.XB4JGaVNL-7-YhD8k8hTfd6cnRv-XKFs8yoZ2OAdCKfHsdStF9SOufrYYFg2y7VvvIMxnFCFzbOw95qx5rZvAQ",
+    "trusted_context": {
+      "issuer": "minekube-connect-test",
+      "trust_domain": "urn:minekube:connect:test:corpus-v2",
+      "audience": "urn:minekube:connect:test:bedrock-principal:v2",
+      "endpoint_id": "endpoint-test",
+      "organization_id": "",
+      "connect_session_id": "session-test",
+      "connect_session_nonce": "AAAAAAAAAAAAAAAAAAAAAA",
+      "source_protocol": "bedrock",
+      "source_protocol_version": 776,
+      "policy_revision": 7
+    },
+    "verification_time_unix": 1785492000,
+    "expected_error": "OK",
+    "expected_principal": {
+      "subject_kind": "bedrock_xuid",
+      "canonical_xuid": "1",
+      "canonical_unlinked_uuid": "00000000-0000-0000-0000-000000000001",
+      "bedrock_display_name": "BedrockOne",
+      "effective_uuid": "00000000-0000-0000-0000-000000000001",
+      "effective_name": "BedrockOne",
+      "verification_method": "minecraft_legacy_chain+client_jwt+ecdh_v1",
+      "kid": "connect-v2-test",
+      "policy_revision": 7
+    }
+  },
+  {
     "name": "valid-linked",
     "compact_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImNvbm5lY3QtYmVkcm9jay1wcmluY2lwYWwrandzO3Y9MiIsImtpZCI6ImNvbm5lY3QtdjItdGVzdCJ9.eyJhdWRpZW5jZSI6InVybjptaW5la3ViZTpjb25uZWN0OnRlc3Q6YmVkcm9jay1wcmluY2lwYWw6djIiLCJiZWRyb2NrX2Rpc3BsYXlfbmFtZSI6IkJlZHJvY2tPbmUiLCJjYW5vbmljYWxfdW5saW5rZWRfdXVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsImNhbm9uaWNhbF94dWlkIjoiMSIsImNvbm5lY3Rfc2Vzc2lvbl9pZCI6InNlc3Npb24tdGVzdCIsImNvbm5lY3Rfc2Vzc2lvbl9ub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJlbmRwb2ludF9pZCI6ImVuZHBvaW50LXRlc3QiLCJleHAiOjE3ODU0OTIwMzAsImlhdCI6MTc4NTQ5MjAwMCwiaXNzdWVyIjoibWluZWt1YmUtY29ubmVjdC10ZXN0IiwianRpIjoiQWdJQ0FnSUNBZ0lDQWdJQ0FnSUNBZyIsImxpbmtlZF9qYXZhIjp7Im5hbWUiOiJKYXZhT25lIiwicHJvdmVuYW5jZSI6eyJwcm92aWRlciI6Im1veHlfYWNjb3VudF9saW5rX3YxIiwicmVjb3JkX2lkIjoicmVjb3JkLXRlc3QtMSIsInJldmlzaW9uIjozLCJ2ZXJpZmllZF9hdCI6MTc4NTQ5MTk5NX0sInV1aWQiOiIxMjNlNDU2Ny1lODliLTEyZDMtYTQ1Ni00MjY2MTQxNzQwMDAifSwibmJmIjoxNzg1NDkyMDAwLCJvcmdhbml6YXRpb25faWQiOiJvcmdhbml6YXRpb24tdGVzdCIsInBvbGljeV9yZXZpc2lvbiI6Nywic291cmNlX3Byb3RvY29sIjoiYmVkcm9jayIsInNvdXJjZV9wcm90b2NvbF92ZXJzaW9uIjo3NzYsInN1YmplY3Rfa2luZCI6ImJlZHJvY2tfbGlua2VkX2phdmEiLCJ0cnVzdF9kb21haW4iOiJ1cm46bWluZWt1YmU6Y29ubmVjdDp0ZXN0OmNvcnB1cy12MiIsInZlcmlmaWNhdGlvbl9tZXRob2QiOiJtaW5lY3JhZnRfZnVsbF9qd2tzK2NsaWVudF9qd3QrZWNkaF92MSIsInZlcnNpb24iOjJ9.S4OQjj4dNz69jsAbCFQu866Bc3YX6i01wMMdzDQw4PGX3MTfNjIxD1XGX3Jp7BQN21RKFJcHDyGlNsVNc5NeCA",
     "trusted_context": {

--- a/bedrockprincipal/types.go
+++ b/bedrockprincipal/types.go
@@ -75,10 +75,13 @@ type VerificationEvidence struct {
 }
 
 type PrincipalBindings struct {
-	Issuer                string
-	TrustDomain           string
-	Audience              string
-	EndpointID            string
+	Issuer      string
+	TrustDomain string
+	Audience    string
+	EndpointID  string
+	// OrganizationID is the optional organization trust-domain dimension. An
+	// empty value denotes an endpoint-scoped principal; the endpoint, session,
+	// nonce, signature, and all other bindings remain mandatory and exact.
 	OrganizationID        string
 	ConnectSessionID      string
 	ConnectSessionNonce   [16]byte

--- a/bedrockprincipal/verifier.go
+++ b/bedrockprincipal/verifier.go
@@ -158,11 +158,19 @@ func publicPrincipalError(err error) PrincipalError {
 }
 
 func validBedrockBinding(sourceProtocol string, sourceProtocolVersion int32, endpointID, organizationID, connectSessionID string) bool {
-	return sourceProtocol == "bedrock" && sourceProtocolVersion >= 1 && validBindingID(endpointID) && validBindingID(organizationID) && validBindingID(connectSessionID)
+	return sourceProtocol == "bedrock" && sourceProtocolVersion >= 1 && validBindingID(endpointID) && validOptionalOrganizationID(organizationID) && validBindingID(connectSessionID)
 }
 
 func validBindingID(value string) bool {
 	return len(value) >= 1 && len(value) <= 128
+}
+
+// validOptionalOrganizationID permits exactly the empty string for endpoints
+// without a dashboard organization. It deliberately does not relax any other
+// binding: endpoint and session IDs stay non-empty, and VerifyAndConsume still
+// compares every signed binding to the trusted proposal context exactly.
+func validOptionalOrganizationID(value string) bool {
+	return value == "" || validBindingID(value)
 }
 
 func validTrustClaims(issuer, trustDomain, audience string) bool {

--- a/bedrockprincipal/verifier_test.go
+++ b/bedrockprincipal/verifier_test.go
@@ -144,6 +144,45 @@ func TestVerifierEnforcesFrozenBedrockBindingSchema(t *testing.T) {
 	}
 }
 
+func TestVerifierAllowsOrglessEndpointScopeButKeepsEveryBindingExact(t *testing.T) {
+	payload := validPayload()
+	payload["organization_id"] = ""
+	expectedContext := trustedContext()
+	expectedContext.OrganizationID = ""
+
+	principal, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, payload)), expectedContext)
+	require.NoError(t, err)
+	require.Empty(t, principal.Bindings().OrganizationID)
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(map[string]any, *TrustedProposalContext)
+	}{
+		{name: "claim organization differs", mutate: func(payload map[string]any, _ *TrustedProposalContext) {
+			payload["organization_id"] = "other-organization"
+		}},
+		{name: "trusted organization differs", mutate: func(_ map[string]any, context *TrustedProposalContext) {
+			context.OrganizationID = "other-organization"
+		}},
+		{name: "endpoint differs", mutate: func(payload map[string]any, _ *TrustedProposalContext) {
+			payload["endpoint_id"] = "other-endpoint"
+		}},
+		{name: "session differs", mutate: func(_ map[string]any, context *TrustedProposalContext) {
+			context.ConnectSessionID = "other-session"
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := validPayload()
+			candidate["organization_id"] = ""
+			expected := trustedContext()
+			expected.OrganizationID = ""
+			tc.mutate(candidate, &expected)
+			_, err := verifierAt(testNowUnix).VerifyAndConsume(context.Background(), mustEnvelope(t, signPayload(t, candidate)), expected)
+			require.ErrorIs(t, err, BindingMismatch)
+		})
+	}
+}
+
 func TestVerifierEnforcesFrozenTrustClaimSchemaMaxima(t *testing.T) {
 	cases := []struct {
 		name   string


### PR DESCRIPTION
Allows a signed `organization_id: ""` for endpoints without a dashboard organization while retaining the field and exact trusted-context equality. Endpoint/session/nonce, signature, policy and replay constraints stay fail-closed.

Includes a deterministic signed cross-component core vector plus mismatch tests for organization, endpoint, and session bindings.

Validation:
- `go run ./bedrockprincipal/internal/vectorcmd -check bedrockprincipal/testdata/v2/core-vectors.json`
- `go test -count=1 ./bedrockprincipal/...`
- `go test -race -count=1 ./bedrockprincipal`
- `go test -count=1 ./...`